### PR TITLE
Use python3-compatible error reporting in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,7 @@ if sys.platform in ("win32","darwin",):
         raise
     import traceback
     traceback.print_exc()
-    print >>sys.stderr, "COULD NOT COPY PRE-BUILT DEPENDENCIES"
+    sys.stderr.write("COULD NOT COPY PRE-BUILT DEPENDENCIES\n")
 
 ##  Now we can import enchant to get at version info
 


### PR DESCRIPTION
Installing from source under Python 3.3 produces:

  Traceback (most recent call last):
    File "setup.py", line 203, in <module>
      print >>sys.stderr, "COULD NOT COPY PRE-BUILT DEPENDENCIES"
  TypeError: unsupported operand type(s) for >>: 'builtin_function_or_method' and '_io.TextIOWrapper'

The problem is the use of the '>>' operator to send a message
to stderr.
