### PR TITLE
Fix for command line in Python 3.x

### DIFF
--- a/enchant/checker/CmdLineChecker.py
+++ b/enchant/checker/CmdLineChecker.py
@@ -89,7 +89,10 @@ class CmdLineChecker:
         printf(["HOW ABOUT:", self.error.suggest()])
     
     def read_command(self):
-        cmd = raw_input(">> ")
+        try:
+            cmd = raw_input(">> ") # Python 2.x
+        except NameError:
+            cmd = input(">> ") # Python 3.x
         cmd = cmd.strip()
         
         if cmd.isdigit():


### PR DESCRIPTION
This fix the command line "mode" changing from `raw_input` to `input` for Python 3.

I have tested this solution under Python 2.7 and Python 3.3 and works fine.
