### PR TITLE
Better handling of unicode prefix_dir on OSX.

### DIFF
--- a/enchant/_enchant.py
+++ b/enchant/_enchant.py
@@ -117,6 +117,8 @@ if e is None and sys.platform == "darwin":
       e = CDLL(e_path)
       try:
           e_dir = os.path.dirname(os.path.dirname(e_path))
+          if isinstance(e_dir,unicode):
+              e_dir = e_dir.encode(sys.getfilesystemencoding())
           prefix_dir = POINTER(c_char_p).in_dll(e,"enchant_prefix_dir_p")
           prefix_dir.contents = c_char_p(e_dir)
       except AttributeError:


### PR DESCRIPTION
This should fix #45 based on @tarekziade suggestion; Tarek can you please sanity-check whether this works for you?  I don't have my OSX machine handy
