### PR TITLE
Use filters keyword argument for get_tokenizer() in docs

### DIFF
--- a/website/content/tutorial.rst
+++ b/website/content/tutorial.rst
@@ -234,7 +234,7 @@ A filter is simply a wrapper around a tokenizer that can (1) drop certain words 
   >>> [w for w in tknzr("send an email to fake@example.com please")]
   [('send', 0), ('an', 5), ('email', 8), ('to', 14), ('fake@example.com', 17), ('please', 34)]
   >>>
-  >>> tknzr = get_tokenizer("en_US",[EmailFilter])
+  >>> tknzr = get_tokenizer("en_US", filters=[EmailFilter])
   >>> [w for w in tknzr("send an email to fake@example.com please")]
   [('send', 0), ('an', 5), ('email', 8), ('to', 14), ('please', 34)]
 


### PR DESCRIPTION
Since 36930b55ac9881445a262a355af74c83ceef28e1, the filters argument is
expected to be a keyword argument.