### PR TITLE
Add trove classifiers for all supported Python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,15 @@ classifiers =
   Intended Audience :: Developers
   License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
   Operating System :: OS Independent
+  Programming Language :: Python
   Programming Language :: Python :: 3
+  Programming Language :: Python :: 3 :: Only
+  Programming Language :: Python :: 3.5
+  Programming Language :: Python :: 3.6
+  Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: Implementation :: CPython
+  Programming Language :: Python :: Implementation :: PyPy
   Topic :: Software Development :: Libraries
   Topic :: Text Processing :: Linguistic
 


### PR DESCRIPTION
The trove classifiers now accurately document that pyenchant is Python 3
only, the specific Python versions supported, and that the PyPy
platform is supported.

These classifiers help new users know, at a quick glance, what is
supported by the library without digging into the docs or README.

These classifiers are also used by scripts and tools for some
automation.

For a complete list of trove classifiers, see:
https://pypi.org/classifiers/