### PR TITLE
Run pyupgrade across the codebase

### DIFF
--- a/enchant/__init__.py
+++ b/enchant/__init__.py
@@ -89,7 +89,7 @@ from enchant.utils import get_default_language
 from enchant.pypwl import PyPWL
 
 
-class ProviderDesc(object):
+class ProviderDesc:
     """Simple class describing an Enchant provider.
 
     Each provider has the following information associated with it:
@@ -122,7 +122,7 @@ class ProviderDesc(object):
         return hash(self.name + self.desc + self.file)
 
 
-class _EnchantObject(object):
+class _EnchantObject:
     """Base class for enchant objects.
 
     This class implements some general functionality for interfacing with
@@ -205,7 +205,7 @@ class Broker(_EnchantObject):
         This method is the constructor for the 'Broker' object.  No
         arguments are required.
         """
-        _EnchantObject.__init__(self)
+        super().__init__()
 
     def _init_this(self):
         self._this = _e.broker_init()
@@ -222,7 +222,7 @@ class Broker(_EnchantObject):
             pass
 
     def __getstate__(self):
-        state = super(Broker, self).__getstate__()
+        state = super().__getstate__()
         state.pop("_live_dicts")
         return state
 
@@ -539,7 +539,7 @@ class Dict(_EnchantObject):
             broker = _broker
         self._broker = broker
         # Now let the superclass initialise the C-library object
-        _EnchantObject.__init__(self)
+        super().__init__()
 
     def _init_this(self):
         # Create dead object if False was given as the tag.
@@ -591,7 +591,7 @@ class Dict(_EnchantObject):
         """
         if self._broker is None or self._broker._this is None:
             self._this = None
-        _EnchantObject._check_this(self, msg)
+        super()._check_this(msg)
 
     def _raise_error(self, default="Unspecified Error", eclass=Error):
         """Overrides _EnchantObject._raise_error to check dict errors."""
@@ -778,7 +778,7 @@ class DictWithPWL(Dict):
         exclude list.  If this file does not exist, it is created with
         default permissions.
         """
-        Dict.__init__(self, tag, broker)
+        super().__init__(tag, broker)
         if pwl is not None:
             if not os.path.exists(pwl):
                 f = open(pwl, "wt")
@@ -802,7 +802,7 @@ class DictWithPWL(Dict):
             self._free()
         if self.pel is None:
             self._free()
-        Dict._check_this(self, msg)
+        super()._check_this(msg)
         self.pwl._check_this(msg)
         self.pel._check_this(msg)
 
@@ -814,7 +814,7 @@ class DictWithPWL(Dict):
         if self.pel is not None:
             self.pel._free()
             self.pel = None
-        Dict._free(self)
+        super()._free()
 
     def check(self, word):
         """Check spelling of a word.
@@ -827,7 +827,7 @@ class DictWithPWL(Dict):
             return False
         if self.pwl.check(word):
             return True
-        if Dict.check(self, word):
+        if super().check(word):
             return True
         return False
 
@@ -837,7 +837,7 @@ class DictWithPWL(Dict):
         This method tries to guess the correct spelling for a given
         word, returning the possibilities in a list.
         """
-        suggs = Dict.suggest(self, word)
+        suggs = super().suggest(word)
         suggs.extend([w for w in self.pwl.suggest(word) if w not in suggs])
         for i in range(len(suggs) - 1, -1, -1):
             if self.pel.check(suggs[i]):

--- a/enchant/checker/CmdLineChecker.py
+++ b/enchant/checker/CmdLineChecker.py
@@ -349,7 +349,7 @@ class CmdLineChecker:
         file's contents into a unicode string.  The output will be written
         in the same encoding.
         """
-        inStr = "".join(open(infile, "r").readlines())
+        inStr = "".join(open(infile).readlines())
         if enc is not None:
             inStr = inStr.decode(enc)
         self._checker.set_text(inStr)

--- a/enchant/checker/GtkSpellCheckerDialog.py
+++ b/enchant/checker/GtkSpellCheckerDialog.py
@@ -52,7 +52,7 @@ def create_list_view(col_label,):
 
 class GtkSpellCheckerDialog(gtk.Window):
     def __init__(self, *args, **kwargs):
-        gtk.Window.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.set_title("Spell check")
         self.set_default_size(350, 200)
 

--- a/enchant/checker/wxSpellCheckerDialog.py
+++ b/enchant/checker/wxSpellCheckerDialog.py
@@ -104,8 +104,7 @@ class wxSpellCheckerDialog(wx.Dialog):
     sz = (300, 70)
 
     def __init__(self, parent=None, id=-1, title="Checking Spelling..."):
-        wx.Dialog.__init__(
-            self,
+        super().__init__(
             parent,
             id,
             title,
@@ -280,7 +279,7 @@ class wxSpellCheckerDialog(wx.Dialog):
 def _test():
     class TestDialog(wxSpellCheckerDialog):
         def __init__(self, *args):
-            wxSpellCheckerDialog.__init__(self, *args)
+            super().__init__(*args)
             wx.EVT_CLOSE(self, self.OnClose)
 
         def OnClose(self, evnt):

--- a/enchant/pypwl.py
+++ b/enchant/pypwl.py
@@ -43,7 +43,6 @@ prototype for the C version found in Enchant).
 
 """
 
-from __future__ import generators
 
 import os
 import warnings
@@ -179,7 +178,7 @@ class PyPWL:
         if pwl is not None:
             self.pwl = os.path.abspath(pwl)
             self.tag = self.pwl
-            pwl_f = open(pwl, "r")
+            pwl_f = open(pwl)
             for ln in pwl_f:
                 word = ln.strip()
                 self.add_to_session(word)

--- a/enchant/tokenize/__init__.py
+++ b/enchant/tokenize/__init__.py
@@ -241,7 +241,7 @@ class empty_tokenize(tokenize):  # noqa: N801
     _DOC_ERRORS = []
 
     def __init__(self):
-        tokenize.__init__(self, "")
+        super().__init__("")
 
     def next(self):
         raise StopIteration()
@@ -253,7 +253,7 @@ class unit_tokenize(tokenize):  # noqa: N801
     _DOC_ERRORS = []
 
     def __init__(self, text):
-        tokenize.__init__(self, text)
+        super().__init__(text)
         self._done = False
 
     def next(self):
@@ -346,7 +346,7 @@ class Chunker(tokenize):
     pass
 
 
-class Filter(object):
+class Filter:
     """Base class for token filtering functions.
 
     A filter is designed to wrap a tokenizer (or another filter) and do
@@ -388,7 +388,7 @@ class Filter(object):
         """
         return unit_tokenize(word)
 
-    class _TokenFilter(object):
+    class _TokenFilter:
         """Private inner class implementing the tokenizer-wrapping logic.
 
         This might seem convoluted, but we're trying to create something

--- a/enchant/tokenize/en.py
+++ b/enchant/tokenize/en.py
@@ -93,7 +93,7 @@ class tokenize(enchant.tokenize.tokenize):  # noqa: N801
             # MySpell provider, disabling for now.
             # Allow unicode typographic apostrophe
             # self._valid_chars = (u"'",u"\u2019")
-            self._valid_chars = (u"'",)
+            self._valid_chars = ("'",)
 
     def _consume_alpha_b(self, text, offset):
         """Consume an alphabetic character from the given bytestring.

--- a/website/conf.py
+++ b/website/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # PyEnchant documentation build configuration file, created by
 # sphinx-quickstart on Thu Apr 28 20:41:16 2011.
@@ -49,8 +48,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"PyEnchant"
-copyright = u"2011, Ryan Kelly"
+project = "PyEnchant"
+copyright = "2011, Ryan Kelly"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -182,7 +181,7 @@ htmlhelp_basename = "PyEnchantdoc"
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "PyEnchant.tex", u"PyEnchant Documentation", u"Ryan Kelly", "manual"),
+    ("index", "PyEnchant.tex", "PyEnchant Documentation", "Ryan Kelly", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
pyupgrade is a tool to automatically upgrade syntax for newer versions
of the Python language. For details, see:
https://github.com/asottile/pyupgrade

As the project is Python 3 only, this tools applies several
simplifications:

- No longer need to specify Python file encoding. Python files are read
as utf-8 by default.

- No longer need to prefix Unicode strings with u. Python 3 strings are
Unicode by default.

- No longer need to inherit from object as Python 3 removed the legacy
old-style classes.

- Use shorter Python 3 super() syntax.

- Remove __future__ imports that are no longer necessary.