### PR TITLE
Make broker destructor less picky

### DIFF
--- a/enchant/__init__.py
+++ b/enchant/__init__.py
@@ -554,7 +554,7 @@ class Dict(_EnchantObject):
         # Calling free() might fail if python is shutting down
         try:
             self._free()
-        except AttributeError:
+        except (AttributeError, TypeError):
             pass
 
     def _switch_this(self, this, broker):


### PR DESCRIPTION
Fixes #98. Copies of a similar exception guard for `Dict.__del__`. 

The underlying problem is that `_e.broker_free_dict` is `None` at the time of calling `__del__`, possibly because it was already garbage collected. I tried to hold a reference to it with `self._e` but it didn't work, the "correct" solution needs to be more clever than that. Since the project already uses similar exception eating technique for the dict destructor, I decided to copy that instead.