### PR TITLE
docs: fix simple typo, tokeniting -> tokenizing

### DIFF
--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -478,5 +478,5 @@ def test_typographic_apostrophe():
     ],
 )
 def test_tokenize_en_byte(text, expected):
-    """Test tokeniting bytes."""
+    """Test tokenizing bytes."""
     assert list(tokenize_en(text)) == expected


### PR DESCRIPTION
There is a small typo in tests/test_tokenize.py.

Should read `tokenizing` rather than `tokeniting`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md