### PR TITLE
Use invoke as a task runner rather than tox

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -24,6 +24,6 @@ jobs:
 
     - name: Run linters
       run: |
-        tox -e linters
+        tox -e py310 lint
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,4 +55,5 @@ jobs:
 
     - name: Run tests
       run: |
-        tox -e ${{ matrix.tox_env }}
+        tox -e ${{ matrix.tox_env }} bootstrap
+        tox -e ${{ matrix.tox_env }} test

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build website
       run: |
-        tox -e website
+        tox -e py310 sphinx
 
     - name: Deploy (if main)
       if: github.ref == 'refs/heads/main'

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,62 @@
+from invoke import call, task
+
+from bootstrap import main as main_bootstrap
+
+
+@task
+def bootstrap(c):
+    main_bootstrap()
+
+
+@task
+def black(c, check=False):
+    print("Running black")
+    cmd = f"black ."
+    if check:
+        cmd += " --check"
+    c.run(cmd)
+
+
+@task
+def isort(c, check=False):
+    print("Running isort")
+    cmd = f"isort ."
+    if check:
+        cmd += " --check"
+    c.run(cmd)
+
+
+@task
+def flake8(c):
+    print("Running flake8")
+    c.run(f"flake8 enchant tests")
+
+
+@task
+def sphinx(c, autobuild=False, builder="html"):
+    build_dir = "website/build"
+    source_dir = "website/content"
+    conf_dir = "website"
+    out_dir = f"website/{builder}"
+    if autobuild:
+        script = "sphinx-autobuild"
+    else:
+        script = "sphinx-build"
+    cmd = f"{script} -build -W -b {builder} -c {conf_dir} {source_dir} {out_dir}"
+    c.run(cmd, echo=True)
+
+
+@task(
+    pre=[
+        call(black, check=True),
+        call(isort, check=True),
+        call(flake8),
+    ]
+)
+def lint(c):
+    pass
+
+
+@task
+def test(c):
+    c.run("pytest")

--- a/tasks.py
+++ b/tasks.py
@@ -37,7 +37,7 @@ def sphinx(c, autobuild=False, builder="html"):
     build_dir = "website/build"
     source_dir = "website/content"
     conf_dir = "website"
-    out_dir = f"website/{builder}"
+    out_dir = f"website/out/{builder}"
     if autobuild:
         script = "sphinx-autobuild"
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,58 +1,36 @@
 [tox]
-envlist = py{35,36,37,38,39,310,py3}
+envlist = py{37,38,39,310,py3}
 
 [testenv]
 # pytest-cov does not seem to work if we
 # don't use usedevelop
 usedevelop = true
 deps =
+  # bootstrap
   requests
+
+  # task runner
+  invoke
+
+  # tests
   pytest
   pytest-cov
 
-commands =
-  python bootstrap.py
-  pytest {posargs:--cov --cov-report term --cov-report html --verbose --capture=no}
-
-[testenv:website]
-basepython = python3
-deps =
-  sphinx
-  sphinx-rtd-theme
-changedir = website
-commands = sphinx-build -W -c . -d build/ -b html content/ html/
-
-
-[testenv:website-dev]
-basepython = python3
-deps =
-  sphinx
-  sphinx-rtd-theme
-  sphinx-autobuild
-changedir = website
-commands = sphinx-autobuild -c . -d build/ -b html content/ html/
-
-
-[testenv:linters]
-basepython = python3
-deps =
+  # linters
   black==21.6b0
   flake8==4.0.1
   isort==5.9.3
   pep8-naming==0.12.1
-commands =
-  black --check .
-  isort --check .
-  flake8 enchant tests
 
+  # website
+  sphinx
+  sphinx-autobuild
+  sphinx-rtd-theme
+  sphinxcontrib-spelling
 
-[testenv:release]
-basepython = python3
-deps =
-  requests
+  # release
   twine
   wheel
 
 commands =
-  python release.py
-  twine upload dist/*
+  invoke {posargs}

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,2 +1,2 @@
 build/
-html/
+out/


### PR DESCRIPTION
TODO:

* [x] Specify dev deps only once
* [x] Factorize code that runs command 
* [x] Fix CI 
* [ ] Update contributing docs

Nothing wrong with tox per se, but I really prefer defining commands to run it Python.

This will make it much easier to implement #274 because we can drive sphinx-build from python