### PR TITLE
Cleanup from before PEP 484 type annotations

### DIFF
--- a/enchant/__init__.py
+++ b/enchant/__init__.py
@@ -541,9 +541,9 @@ class Dict(_EnchantObject):
         if tag is None:
             tag = get_default_language()
             if tag is None:
-                err = "No tag specified and default language could not "
-                err = err + "be determined."
-                raise Error(err)
+                raise Error(
+                    "No tag specified and default language could not be determined."
+                )
         self.tag = tag
         # If no broker was given, use the default broker
         if broker is None:

--- a/enchant/checker/__init__.py
+++ b/enchant/checker/__init__.py
@@ -217,9 +217,7 @@ class SpellChecker:
         as input, False if it wants normal strings.  It's important to
         provide the correct type of string to the checker.
         """
-        if self._text.typecode == "u":
-            return True
-        return False
+        return self._text.typecode == "u"
 
     def coerce_string(self, text: str, enc: Optional[str] = None) -> str:
         """Coerce string into the required type.

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -234,13 +234,9 @@ def test_default_language():
     # Two cases: either SpellChecker() without argument works
     # and its lang is the default language, or
     # it does not and we get a DefaultLanguageNotFoundError
-    caught_err = None
     try:
         checker = SpellChecker()
-    except DefaultLanguageNotFoundError as e:
-        caught_err = e
-
-    if caught_err:
+    except DefaultLanguageNotFoundError:
         # At this point, caught_err must be DefaultLanguageNotFoundError, so
         # we're done testing
         return

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -114,7 +114,7 @@ def test_chunkers():
 class TestChunkersAndFilters:
     """Test SpellChecker with the 'chunkers' and 'filters' arguments."""
 
-    text = """I contain <html a=xjvf>tags</html> that should be skipped
+    text = """I contain <xjvf a=xjvf>tags</xjvf> that should be skipped
               along with a <a href='http://example.com/">link to
               http://example.com/</a> that should also be skipped"""
 
@@ -138,7 +138,7 @@ class TestChunkersAndFilters:
             filters=[enchant.tokenize.URLFilter],
         )
         for err in chkr:
-            assert err.word == "html"
+            assert err.word == "xjvf"
             break
         assert chkr.get_text() == self.text
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -111,33 +111,48 @@ def test_chunkers():
     assert chkr.get_text() == text
 
 
-def test_chunkers_and_filters():
+class TestChunkersAndFilters:
     """Test SpellChecker with the 'chunkers' and 'filters' arguments."""
+
     text = """I contain <html a=xjvf>tags</html> that should be skipped
               along with a <a href='http://example.com/">link to
               http://example.com/</a> that should also be skipped"""
-    # There are no errors when things are correctly skipped
-    chkr = SpellChecker(
-        "en_US",
-        text=text,
-        filters=[enchant.tokenize.URLFilter],
-        chunkers=[enchant.tokenize.HTMLChunker],
-    )
-    for err in chkr:
-        pytest.fail("Extraneous spelling errors were found")
-    assert chkr.get_text() == text
-    # The "html" is an error when not using HTMLChunker
-    chkr = SpellChecker("en_US", text=text, filters=[enchant.tokenize.URLFilter])
-    for err in chkr:
-        assert err.word == "html"
-        break
-    assert chkr.get_text() == text
-    # The "http" from the URL is an error when not using URLFilter
-    chkr = SpellChecker("en_US", text=text, chunkers=[enchant.tokenize.HTMLChunker])
-    for err in chkr:
-        assert err.word == "http"
-        break
-    assert chkr.get_text() == text
+
+    def test_chunkers_and_filters(self) -> None:
+        # There are no errors when things are correctly skipped
+        chkr = SpellChecker(
+            "en_US",
+            text=self.text,
+            filters=[enchant.tokenize.URLFilter],
+            chunkers=[enchant.tokenize.HTMLChunker],
+        )
+        for err in chkr:
+            pytest.fail("Extraneous spelling errors were found")
+        assert chkr.get_text() == self.text
+
+    def test_filter_only(self) -> None:
+        # The "html" is an error when not using HTMLChunker
+        chkr = SpellChecker(
+            "en_US",
+            text=self.text,
+            filters=[enchant.tokenize.URLFilter],
+        )
+        for err in chkr:
+            assert err.word == "html"
+            break
+        assert chkr.get_text() == self.text
+
+    def test_chunkter_only(self) -> None:
+        # The "http" from the URL is an error when not using URLFilter
+        chkr = SpellChecker(
+            "en_US",
+            text=self.text,
+            chunkers=[enchant.tokenize.HTMLChunker],
+        )
+        for err in chkr:
+            assert err.word == "http"
+            break
+        assert chkr.get_text() == self.text
 
 
 def test_unicode():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -11,6 +11,6 @@ def test_get_user_config_dir():
     """
     try:
         user_dir = enchant.get_user_config_dir()
-        print(user_dir)
+        assert user_dir
     except AttributeError:
-        pass
+        assert True

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -20,8 +20,5 @@ def check_words(words):
 def test_can_use_multiprocessing():
     words = ["hello" for i in range(1000)]
     input = [words for i in range(1000)]
-    print("Starting")
     pool = Pool(10)
-    for i, result in enumerate(pool.imap_unordered(check_words, input)):
-        assert result
-    print("Finished")
+    assert all(pool.imap_unordered(check_words, input))

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -83,8 +83,6 @@ of words. Also need to "test" the (handling) of 'quoted' words."""
         ("words", 177),
     ]
     assert output == [i for i in basic_tokenize(input)]
-    for (itm_o, itm_v) in zip(output, basic_tokenize(input)):
-        assert itm_o == itm_v
 
 
 def test_tokenize_strip():
@@ -101,8 +99,6 @@ def test_tokenize_strip():
         (">>", 51),
     ]
     assert output == [i for i in basic_tokenize(input)]
-    for (itm_o, itm_v) in zip(output, basic_tokenize(input)):
-        assert itm_o, itm_v
 
 
 def test_wrap_tokenizer():
@@ -307,8 +303,6 @@ def test_html_chunker():
         ("characters", 190),
     ]
     assert out == exp
-    for (word, pos) in out:
-        assert text[pos : pos + len(word)] == word
 
 
 def test_tokenize_en():
@@ -349,8 +343,6 @@ of words. Also need to "test" the handling of 'quoted' words."""
         ("quoted", 167),
         ("words", 175),
     ]
-    for (itm_o, itm_v) in zip(output, tokenize_en(input)):
-        assert itm_o == itm_v
 
 
 def test_unicode_basic():
@@ -390,8 +382,6 @@ def test_bug1591450():
         ("numbers", 104),
         ("Done", 134),
     ]
-    for (itm_o, itm_v) in zip(output, tokenize_en(input)):
-        assert itm_o == itm_v
 
 
 def test_bug2785373():

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -49,7 +49,7 @@ def test_basic_tokenize():
     input = """This is a paragraph.  It's not very special, but it's designed
 2 show how the splitter works with many-different combos
 of words. Also need to "test" the (handling) of 'quoted' words."""
-    output = [
+    assert list(basic_tokenize(input)) == [
         ("This", 0),
         ("is", 5),
         ("a", 8),
@@ -82,13 +82,12 @@ of words. Also need to "test" the (handling) of 'quoted' words."""
         ("quoted", 169),
         ("words", 177),
     ]
-    assert output == [i for i in basic_tokenize(input)]
 
 
 def test_tokenize_strip():
     """Test special-char-stripping edge-cases in basic_tokenize."""
     input = "((' <this> \"\" 'text' has (lots) of (special chars} >>]"
-    output = [
+    assert list(basic_tokenize(input)) == [
         ("<this>", 4),
         ("text", 15),
         ("has", 21),
@@ -98,7 +97,6 @@ def test_tokenize_strip():
         ("chars}", 44),
         (">>", 51),
     ]
-    assert output == [i for i in basic_tokenize(input)]
 
 
 def test_wrap_tokenizer():
@@ -166,9 +164,8 @@ def test_text():
 
 def test_url_filter(test_text):
     """Test filtering of URLs"""
-    tkns = get_tokenizer("en_US", filters=(URLFilter,))(test_text)
-    out = [t for t in tkns]
-    exp = [
+    tknzr = get_tokenizer("en_US", filters=(URLFilter,))
+    assert list(tknzr(test_text)) == [
         ("this", 0),
         ("text", 5),
         ("with", 10),
@@ -186,14 +183,12 @@ def test_url_filter(test_text):
         ("as", 157),
         ("well", 160),
     ]
-    assert out == exp
 
 
 def test_wiki_word_filter(test_text):
     """Test filtering of WikiWords"""
-    tkns = get_tokenizer("en_US", filters=(WikiWordFilter,))(test_text)
-    out = [t for t in tkns]
-    exp = [
+    tknzr = get_tokenizer("en_US", filters=(WikiWordFilter,))
+    assert list(tknzr(test_text)) == [
         ("this", 0),
         ("text", 5),
         ("with", 10),
@@ -219,14 +214,12 @@ def test_wiki_word_filter(test_text):
         ("as", 157),
         ("well", 160),
     ]
-    assert out == exp
 
 
 def test_email_filter(test_text):
     """Test filtering of email addresses"""
-    tkns = get_tokenizer("en_US", filters=(EmailFilter,))(test_text)
-    out = [t for t in tkns]
-    exp = [
+    tknzr = get_tokenizer("en_US", filters=(EmailFilter,))
+    assert list(tknzr(test_text)) == [
         ("this", 0),
         ("text", 5),
         ("with", 10),
@@ -250,16 +243,12 @@ def test_email_filter(test_text):
         ("as", 157),
         ("well", 160),
     ]
-    assert out == exp
 
 
 def test_combined_filter(test_text):
     """Test several filters combined"""
-    tkns = get_tokenizer("en_US", filters=(URLFilter, WikiWordFilter, EmailFilter))(
-        test_text
-    )
-    out = [t for t in tkns]
-    exp = [
+    tknzr = get_tokenizer("en_US", filters=(URLFilter, WikiWordFilter, EmailFilter))
+    assert list(tknzr(test_text)) == [
         ("this", 0),
         ("text", 5),
         ("with", 10),
@@ -271,7 +260,6 @@ def test_combined_filter(test_text):
         ("as", 157),
         ("well", 160),
     ]
-    assert out == exp
 
 
 def test_html_chunker():
@@ -280,9 +268,8 @@ def test_html_chunker():
               <b>simple</b> HTML document for <p> test<i>ing</i> purposes</p>.
             It < contains > various <-- special characters.
             """
-    tkns = get_tokenizer("en_US", chunkers=(HTMLChunker,))(text)
-    out = [t for t in tkns]
-    exp = [
+    tknzr = get_tokenizer("en_US", chunkers=(HTMLChunker,))
+    assert list(tknzr(text)) == [
         ("hello", 0),
         ("my", 24),
         ("title", 27),
@@ -302,7 +289,6 @@ def test_html_chunker():
         ("special", 182),
         ("characters", 190),
     ]
-    assert out == exp
 
 
 def test_tokenize_en():
@@ -310,7 +296,7 @@ def test_tokenize_en():
     input = """This is a paragraph.  It's not very special, but it's designed
 2 show how the splitter works with many-different combos
 of words. Also need to "test" the handling of 'quoted' words."""
-    output = [
+    assert list(tokenize_en(input)) == [
         ("This", 0),
         ("is", 5),
         ("a", 8),
@@ -358,7 +344,7 @@ def test_unicode_basic():
 def test_bug1591450():
     """Check for tokenization regressions identified in bug #1591450."""
     input = """Testing <i>markup</i> and {y:i}so-forth...leading dots and trail--- well, you get-the-point. Also check numbers: 999 1,000 12:00 .45. Done?"""
-    output = [
+    assert list(tokenize_en(input)) == [
         ("Testing", 0),
         ("i", 9),
         ("markup", 11),
@@ -408,7 +394,7 @@ def test_finnish_text():
         Ulkomaisia sanoja süss, spaß.
     """
     )
-    expected_tokens = [
+    assert list(tokenize_en(text)) == [
         ("Tämä", 0),
         ("on", 5),
         ("kappale", 8),
@@ -441,14 +427,16 @@ def test_finnish_text():
         ("süss", 233),
         ("spaß", 239),
     ]
-    assert list(tokenize_en(text)) == expected_tokens
 
 
 def test_typographic_apostrophe():
     """ "Typographic apostrophes should be word separators in English."""
     text = "They\u2019re here"
-    expected_tokens = [("They", 0), ("re", 5), ("here", 8)]
-    assert list(tokenize_en(text)) == expected_tokens
+    assert list(tokenize_en(text)) == [
+        ("They", 0),
+        ("re", 5),
+        ("here", 8),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py{37,38,39,310,py3}
+skip_missing_interpreters = true
 
 [testenv]
 # pytest-cov does not seem to work if we

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39,310,py3}
+envlist = py{37,38,39,310,py3}
 
 [testenv]
 # pytest-cov does not seem to work if we


### PR DESCRIPTION
While working on https://github.com/pyenchant/pyenchant/pull/255 I found several small issues when testing locally.
- f3dff22 ci: skip_missing_interpreters
- 04d3c45 ci: Also drop Python 3.5 and 3.6 from tox
- e3b00d1 style[test]: Simplify test case
- ca07241 style[checker]: Simplify boolean logic
- 389c6d7 test[checker]: Use invalid word for HTML tag
- c63e5e4 test[checker]: Split test in 3
- 1f47238 test[multiproc]: Assert on all()
- e19934a test[misc]: Assert get_user_config_dir()
- 21885ac style[enchant]: Simplify Error raising
