### PR TITLE
Improve documentation

### DIFF
--- a/enchant/__init__.py
+++ b/enchant/__init__.py
@@ -37,7 +37,7 @@ visit the project website:
 
     https://abiword.github.io/enchant/
 
-Spellchecking is performed using 'Dict' objects, which represent
+Spellchecking is performed using :py:class:`Dict` objects, which represent
 a language dictionary.  Their use is best demonstrated by a quick
 example::
 
@@ -56,18 +56,18 @@ including an additional code - for example, "en_AU" refers to Australian
 English.  The later form is preferred as it is more widely supported.
 
 To check whether a dictionary exists for a given language, the function
-'dict_exists' is available.  Dictionaries may also be created using the
-function 'request_dict'.
+:py:func:`dict_exists` is available.  Dictionaries may also be created using the
+function :py:func:`request_dict`.
 
 A finer degree of control over the dictionaries and how they are created
-can be obtained using one or more 'Broker' objects.  These objects are
+can be obtained using one or more :py:class:`Broker` objects.  These objects are
 responsible for locating dictionaries for a specific language.
 
 Note that unicode strings are expected throughout the entire API.
 Bytestrings should not be passed into any function.
 
 Errors that occur in this module are reported by raising subclasses
-of 'Error'.
+of :py:exc:`~.errors.Error`.
 
 """
 _DOC_ERRORS = ["enchnt", "enchnt", "incant", "fr"]
@@ -97,9 +97,9 @@ class ProviderDesc:
 
     Each provider has the following information associated with it:
 
-        * name:        Internal provider name (e.g. "aspell")
-        * desc:        Human-readable description (e.g. "Aspell Provider")
-        * file:        Location of the library containing the provider
+        * :py:attr:`name`:        Internal provider name (e.g. "aspell")
+        * :py:attr:`desc`:        Human-readable description (e.g. "Aspell Provider")
+        * :py:attr:`file`:        Location of the library containing the provider
 
     """
 
@@ -134,8 +134,8 @@ class _EnchantObject:
     the '_enchant' C-library in a consistent way.  All public objects
     from the 'enchant' module are subclasses of this class.
 
-    All enchant objects have an attribute '_this' which contains the
-    pointer to the underlying C-library object.  The method '_check_this'
+    All enchant objects have an attribute :py:attr:`_this` which contains the
+    pointer to the underlying C-library object.  The method :py:meth:`_check_this`
     can be called to ensure that this point is not None, raising an
     exception if it is.
     """
@@ -149,7 +149,7 @@ class _EnchantObject:
             self._init_this()
 
     def _check_this(self, msg: str = None) -> None:
-        """Check that self._this is set to a pointer, rather than None."""
+        """Check that :py:attr:`_this` is set to a pointer, rather than `None`."""
         if self._this is None:
             if msg is None:
                 msg = "%s unusable: the underlying C-library object has been freed."
@@ -165,11 +165,11 @@ class _EnchantObject:
     ) -> NoReturn:
         """Raise an exception based on available error messages.
 
-        This method causes an Error to be raised.  Subclasses should
+        This method causes an :py:exc:`~.errors.Error` to be raised.  Subclasses should
         override it to retrieve an error indication from the underlying
         API if possible.  If such a message cannot be retrieved, the
-        argument value <default> is used.  The class of the exception
-        can be specified using the argument <eclass>
+        argument value `default` is used.  The class of the exception
+        can be specified using the argument `eclass`
         """
         raise eclass(default)
 
@@ -193,10 +193,10 @@ class _EnchantObject:
 class Broker(_EnchantObject):
     """Broker object for the Enchant spellchecker.
 
-    Broker objects are responsible for locating and managing dictionaries.
-    Unless custom functionality is required, there is no need to use Broker
-    objects directly. The 'enchant' module provides a default broker object
-    so that 'Dict' objects can be created directly.
+    `Broker` objects are responsible for locating and managing dictionaries.
+    Unless custom functionality is required, there is no need to use `Broker`
+    objects directly. The py:mod:`enchant` module provides a default broker object
+    so that :py:class:`Dict` objects can be created directly.
 
     The most important methods of this class include:
 
@@ -209,7 +209,7 @@ class Broker(_EnchantObject):
     def __init__(self) -> None:
         """Broker object constructor.
 
-        This method is the constructor for the 'Broker' object.  No
+        This method is the constructor for the `Broker` object.  No
         arguments are required.
         """
         super().__init__()
@@ -246,9 +246,9 @@ class Broker(_EnchantObject):
         """Free system resource associated with a Broker object.
 
         This method can be called to free the underlying system resources
-        associated with a Broker object.  It is called automatically when
+        associated with a `Broker` object.  It is called automatically when
         the object is garbage collected.  If called explicitly, the
-        Broker and any associated Dict objects must no longer be used.
+        `Broker` and any associated `Dict` objects must no longer be used.
         """
         if self._this is not None:
             # During shutdown, this finalizer may be called before
@@ -261,21 +261,21 @@ class Broker(_EnchantObject):
             self._this = None
 
     def request_dict(self, tag: str = None) -> "Dict":
-        """Request a Dict object for the language specified by <tag>.
+        """Request a :py:class:`Dict` object for the language specified by `tag`.
 
-        This method constructs and returns a Dict object for the
-        requested language.  'tag' should be a string of the appropriate
+        This method constructs and returns a :py:class:`Dict` object for the
+        requested language.  `tag` should be a string of the appropriate
         form for specifying a language, such as "fr" (French) or "en_AU"
         (Australian English).  The existence of a specific language can
-        be tested using the 'dict_exists' method.
+        be tested using the method :py:meth:`dict_exists`.
 
-        If <tag> is not given or is None, an attempt is made to determine
-        the current language in use.  If this cannot be determined, Error
+        If `tag` is not given or is `None`, an attempt is made to determine
+        the current language in use.  If this cannot be determined, :py:exc:`~.errors.Error`
         is raised.
 
         .. note::
-            this method is functionally equivalent to calling the Dict()
-            constructor and passing in the <broker> argument.
+            this method is functionally equivalent to calling the :py:class:`Dict()`
+            constructor and passing in the `broker` argument.
 
         """
         return Dict(tag, self)
@@ -303,7 +303,7 @@ class Broker(_EnchantObject):
     def request_pwl_dict(self, pwl: str) -> "Dict":
         """Request a Dict object for a personal word list.
 
-        This method behaves as 'request_dict' but rather than returning
+        This method behaves as :py:meth:`request_dict` but rather than returning
         a dictionary for a specific language, it returns a dictionary
         referencing a personal word list.  A personal word list is a file
         of custom dictionary entries, one word per line.
@@ -324,8 +324,8 @@ class Broker(_EnchantObject):
     def _free_dict(self, dict: "Dict") -> None:
         """Free memory associated with a dictionary.
 
-        This method frees system resources associated with a Dict object.
-        It is equivalent to calling the object's 'free' method.  Once this
+        This method frees system resources associated with a `Dict` object.
+        It is equivalent to calling the object`s `free' method.  Once this
         method has been called on a dictionary, it must not be used again.
         """
         self._free_dict_data(dict._this)
@@ -344,8 +344,8 @@ class Broker(_EnchantObject):
         """Check availability of a dictionary.
 
         This method checks whether there is a dictionary available for
-        the language specified by 'tag'.  It returns True if a dictionary
-        is available, and False otherwise.
+        the language specified by `tag`.  It returns `True` if a dictionary
+        is available, and `False` otherwise.
         """
         self._check_this()
         val = _e.broker_dict_exists(self._this, tag.encode())
@@ -356,11 +356,11 @@ class Broker(_EnchantObject):
 
         The Enchant library supports the use of multiple dictionary programs
         and multiple languages.  This method specifies which dictionaries
-        the broker should prefer when dealing with a given language.  'tag'
-        must be an appropriate language specification and 'ordering' is a
+        the broker should prefer when dealing with a given language.  `tag`
+        must be an appropriate language specification and `ordering` is a
         string listing the dictionaries in order of preference.  For example
         a valid ordering might be "aspell,myspell,ispell".
-        The value of 'tag' can also be set to "*" to set a default ordering
+        The value of `tag` can also be set to "*" to set a default ordering
         for all languages for which one has not been set explicitly.
         """
         self._check_this()
@@ -371,7 +371,7 @@ class Broker(_EnchantObject):
 
         This method returns a list of descriptions of each of the
         dictionary providers available.  Each entry in the list is a
-        ProviderDesc object.
+        :py:class:`ProviderDesc` object.
         """
         self._check_this()
         self.__describe_result = []
@@ -382,8 +382,8 @@ class Broker(_EnchantObject):
         """Collector callback for dictionary description.
 
         This method is used as a callback into the _enchant function
-        'enchant_broker_describe'.  It collects the given arguments in
-        a tuple and appends them to the list '__describe_result'.
+        `enchant_broker_describe`.  It collects the given arguments in
+        a tuple and appends them to the list :py:attr:`__describe_result`.
         """
         name = name.decode()
         desc = desc.decode()
@@ -398,8 +398,8 @@ class Broker(_EnchantObject):
 
             (tag,provider)
 
-        where <tag> is the language lag for the dictionary and
-        <provider> is a ProviderDesc object describing the provider
+        where `tag` is the language lag for the dictionary and
+        `provider` is a :py:class:`ProviderDesc` object describing the provider
         through which that dictionary can be obtained.
         """
         self._check_this()
@@ -411,8 +411,8 @@ class Broker(_EnchantObject):
         """Collector callback for listing dictionaries.
 
         This method is used as a callback into the _enchant function
-        'enchant_broker_list_dicts'.  It collects the given arguments into
-        an appropriate tuple and appends them to '__list_dicts_result'.
+        `enchant_broker_list_dicts`.  It collects the given arguments into
+        an appropriate tuple and appends them to :py:attr:`__list_dicts_result`.
         """
         tag = tag.decode()
         name = name.decode()
@@ -434,7 +434,7 @@ class Broker(_EnchantObject):
 
     def __describe_dict(self, dict_data):
         """Get the description tuple for a dict data object.
-        <dict_data> must be a C-library pointer to an enchant dictionary.
+        `dict_data` must be a C-library pointer to an enchant dictionary.
         The return value is a tuple of the form:
                 (<tag>,<name>,<desc>,<file>)
         """
@@ -494,24 +494,24 @@ class Dict(_EnchantObject):
 
     Dictionary objects are responsible for checking the spelling of words
     and suggesting possible corrections.  Each dictionary is owned by a
-    Broker object, but unless a new Broker has explicitly been created
-    then this will be the 'enchant' module default Broker and is of little
+    :py:class:`Broker` object, but unless a new :py:class:`Broker` has explicitly been created
+    then this will be the :py:mod:`enchant` module default :py:class:`Broker` and is of little
     interest.
 
     The important methods of this class include:
 
-        * check():              check whether a word id spelled correctly
-        * suggest():            suggest correct spellings for a word
-        * add():                add a word to the user's personal dictionary
-        * remove():             add a word to the user's personal exclude list
-        * add_to_session():     add a word to the current spellcheck session
-        * store_replacement():  indicate a replacement for a given word
+        * :py:meth:`check()`:              check whether a word id spelled correctly
+        * :py:meth:`suggest()`:            suggest correct spellings for a word
+        * :py:meth:`add()`:                add a word to the user's personal dictionary
+        * :py:meth:`remove()`:             add a word to the user's personal exclude list
+        * :py:meth:`add_to_session()`:     add a word to the current spellcheck session
+        * :py:meth:`store_replacement()`:  indicate a replacement for a given word
 
     Information about the dictionary is available using the following
     attributes:
 
-        * tag:        the language tag of the dictionary
-        * provider:   a ProviderDesc object for the dictionary provider
+        * :py:attr:`tag`:        the language tag of the dictionary
+        * :py:attr:`provider`:   a :py:class:`ProviderDesc` object for the dictionary provider
 
     """
 
@@ -521,18 +521,18 @@ class Dict(_EnchantObject):
         """Dict object constructor.
 
         A dictionary belongs to a specific language, identified by the
-        string <tag>.  If the tag is not given or is None, an attempt to
-        determine the language currently in use is made using the 'locale'
-        module.  If the current language cannot be determined, Error is raised.
+        string `tag`.  If the tag is not given or is `None`, an attempt to
+        determine the language currently in use is made using the :py:mod:`locale`
+        module.  If the current language cannot be determined, :py:exc:`~.errors.Error` is raised.
 
-        If <tag> is instead given the value of False, a 'dead' Dict object
+        If `tag` is instead given the value of `False`, a 'dead' Dict object
         is created without any reference to a language.  This is typically
         only useful within PyEnchant itself.  Any other non-string value
-        for <tag> raises Error.
+        for `tag` raises :py:exc:`~.errors.Error`.
 
-        Each dictionary must also have an associated Broker object which
+        Each dictionary must also have an associated `Broker` object which
         obtains the dictionary information from the underlying system. This
-        may be specified using <broker>.  If not given, the default broker
+        may be specified using `broker`.  If not given, the default broker
         is used.
         """
         # Initialise misc object attributes to None
@@ -571,15 +571,15 @@ class Dict(_EnchantObject):
     def _switch_this(self, this, broker: Broker) -> None:
         """Switch the underlying C-library pointer for this object.
 
-        As all useful state for a Dict is stored by the underlying C-library
+        As all useful state for a `Dict` is stored by the underlying C-library
         pointer, it is very convenient to allow this to be switched at
         run-time.  Pass a new dict data object into this method to affect
-        the necessary changes.  The creating Broker object (at the Python
+        the necessary changes.  The creating `Broker` object (at the Python
         level) must also be provided.
 
         This should *never* *ever* be used by application code.  It's
-        a convenience for developers only, replacing the clunkier <data>
-        parameter to __init__ from earlier versions.
+        a convenience for developers only, replacing the clunkier `data`
+        parameter to `__init__` from earlier versions.
         """
         # Free old dict data
         Dict._free(self)
@@ -594,11 +594,11 @@ class Dict(_EnchantObject):
     _switch_this._DOC_ERRORS = ["init"]  # type: ignore
 
     def _check_this(self, msg: Optional[str] = None) -> None:
-        """Extend _EnchantObject._check_this() to check Broker validity.
+        """Extend `_EnchantObject._check_this()` to check Broker validity.
 
         It is possible for the managing Broker object to be freed without
-        freeing the Dict.  Thus validity checking must take into account
-        self._broker._this as well as self._this.
+        freeing the `Dict`.  Thus validity checking must take into account
+        `self._broker._this` as well as `self._this`.
         """
         if self._broker is None or self._broker._this is None:
             self._this = None
@@ -607,17 +607,17 @@ class Dict(_EnchantObject):
     def _raise_error(
         self, default: str = "Unspecified Error", eclass: Type[Error] = Error
     ) -> NoReturn:
-        """Overrides _EnchantObject._raise_error to check dict errors."""
+        """Overrides `_EnchantObject._raise_error` to check dict errors."""
         err = _e.dict_get_error(self._this)
         if err == "" or err is None:
             raise eclass(default)
         raise eclass(err.decode())
 
     def _free(self) -> None:
-        """Free the system resources associated with a Dict object.
+        """Free the system resources associated with a `Dict` object.
 
-        This method frees underlying system resources for a Dict object.
-        Once it has been called, the Dict object must no longer be used.
+        This method frees underlying system resources for a `Dict` object.
+        Once it has been called, the `Dict` object must no longer be used.
         It is called automatically when the object is garbage collected.
         """
         if self._this is not None:
@@ -630,7 +630,7 @@ class Dict(_EnchantObject):
         """Check spelling of a word.
 
         This method takes a word in the dictionary language and returns
-        True if it is correctly spelled, and false otherwise.
+        `True` if it is correctly spelled, and `False` otherwise.
         """
         self._check_this()
         # Enchant asserts that the word is non-empty.
@@ -702,9 +702,9 @@ class Dict(_EnchantObject):
         """Store a replacement spelling for a miss-spelled word.
 
         This method makes a suggestion to the spellchecking engine that the
-        miss-spelled word <mis> is in fact correctly spelled as <cor>.  Such
-        a suggestion will typically mean that <cor> appears early in the
-        list of suggested spellings offered for later instances of <mis>.
+        miss-spelled word `mis` is in fact correctly spelled as `cor`.  Such
+        a suggestion will typically mean that `cor` appears early in the
+        list of suggested spellings offered for later instances of `mis`.
         """
         if not mis:
             raise ValueError("can't store replacement for an empty string")
@@ -728,7 +728,7 @@ class Dict(_EnchantObject):
             * dictionary file
 
         Direct use of this method is not recommended - instead, access this
-        information through the 'tag' and 'provider' attributes.
+        information through the attributes :py:attr:`tag` and :py:attr:`provider`.
         """
         if check_this:
             self._check_this()
@@ -738,9 +738,9 @@ class Dict(_EnchantObject):
     def __describe_callback(self, tag, name, desc, file):
         """Collector callback for dictionary description.
 
-        This method is used as a callback into the _enchant function
-        'enchant_dict_describe'.  It collects the given arguments in
-        a tuple and stores them in the attribute '__describe_result'.
+        This method is used as a callback into the `_enchant` function
+        `enchant_dict_describe`.  It collects the given arguments in
+        a tuple and stores them in the attribute :py:attr:`__describe_result`.
         """
         tag = tag.decode()
         name = name.decode()
@@ -758,24 +758,24 @@ class DictWithPWL(Dict):
         to explicitly maintain a separate word list in addition to
         the default one.
 
-    This class behaves as the standard Dict class, but also manages a
+    This class behaves as the standard class :py:class:`Dict`, but also manages a
     personal word list stored in a separate file.  The file must be
-    specified at creation time by the 'pwl' argument to the constructor.
+    specified at creation time by the `pwl` argument to the constructor.
     Words added to the dictionary are automatically appended to the pwl file.
 
     A personal exclude list can also be managed, by passing another filename
-    to the constructor in the optional 'pel' argument.  If this is not given,
+    to the constructor in the optional `pel` argument.  If this is not given,
     requests to exclude words are ignored.
 
-    If either 'pwl' or 'pel' are None, an in-memory word list is used.
-    This will prevent calls to add() and remove() from affecting the user's
+    If either `pwl` or `pel` are `None`, an in-memory word list is used.
+    This will prevent calls to :py:meth:`add()` and :py:meth:`remove()` from affecting the user's
     default word lists.
 
-    The Dict object managing the PWL is available as the 'pwl' attribute.
-    The Dict object managing the PEL is available as the 'pel' attribute.
+    The `Dict` object managing the PWL is available as the :py:attr:`pwl` attribute.
+    The `Dict` object managing the PEL is available as the :py:attr:`pel` attribute.
 
-    To create a DictWithPWL from the user's default language, use None
-    as the 'tag' argument.
+    To create a `DictWithPWL` from the user's default language, use `None`
+    as the `tag` argument.
     """
 
     _DOC_ERRORS = ["pel", "pel", "PEL", "pel"]
@@ -785,11 +785,11 @@ class DictWithPWL(Dict):
     ) -> None:
         """DictWithPWL constructor.
 
-        The argument 'pwl', if not None, names a file containing the
+        The argument `pwl`, if not `None,` names a file containing the
         personal word list.  If this file does not exist, it is created
         with default permissions.
 
-        The argument 'pel', if not None, names a file containing the personal
+        The argument `pel`, if not `None,` names a file containing the personal
         exclude list.  If this file does not exist, it is created with
         default permissions.
         """
@@ -814,7 +814,7 @@ class DictWithPWL(Dict):
             self.pel = PyPWL()
 
     def _check_this(self, msg: Optional[str] = None) -> None:
-        """Extend Dict._check_this() to check PWL validity."""
+        """Extend :py:meth:`Dict._check_this()` to check PWL validity."""
         if self.pwl is None:
             self._free()
         if self.pel is None:
@@ -824,7 +824,7 @@ class DictWithPWL(Dict):
         self.pel._check_this(msg)
 
     def _free(self) -> None:
-        """Extend Dict._free() to free the PWL as well."""
+        """Extend :py:meth:`Dict._free()` to free the PWL as well."""
         if self.pwl is not None:
             self.pwl._free()
             self.pwl = None
@@ -837,7 +837,7 @@ class DictWithPWL(Dict):
         """Check spelling of a word.
 
         This method takes a word in the dictionary language and returns
-        True if it is correctly spelled, and false otherwise.  It checks
+        `True` if it is correctly spelled, and `False` otherwise.  It checks
         both the dictionary and the personal word list.
         """
         if self.pel.check(word):

--- a/enchant/checker/CmdLineChecker.py
+++ b/enchant/checker/CmdLineChecker.py
@@ -31,7 +31,7 @@
 
     enchant.checker.CmdLineChecker:  Command-Line spell checker
 
-    This module provides the class CmdLineChecker, which interactively
+    This module provides the class :py:class:`CmdLineChecker`, which interactively
     spellchecks a piece of text by interacting with the user on the
     command line.  It can also be run as a script to spellcheck a file.
 
@@ -320,10 +320,10 @@ class CmdLineChecker:
     ) -> None:
         """Run spellchecking on the named file.
         This method can be used to run the spellchecker over the named file.
-        If <outfile> is not given, the corrected contents replace the contents
-        of <infile>.  If <outfile> is given, the corrected contents will be
+        If `outfile` is not given, the corrected contents replace the contents
+        of `infile`.  If `outfile` is given, the corrected contents will be
         written to that file.  Use "-" to have the contents written to stdout.
-        If <enc> is given, it specifies the encoding used to read the
+        If `enc` is given, it specifies the encoding used to read the
         file's contents into a unicode string.  The output will be written
         in the same encoding.
         """

--- a/enchant/checker/__init__.py
+++ b/enchant/checker/__init__.py
@@ -36,7 +36,7 @@ This package is designed to host higher-level spellchecking functionality
 than is available in the base enchant package.  It should make writing
 applications that follow common usage idioms significantly easier.
 
-The most useful class is SpellChecker, which implements a spellchecking
+The most useful class is :py:class:`SpellChecker`, which implements a spellchecking
 loop over a block of text.  It is capable of modifying the text in-place
 if given an array of characters to work with.
 
@@ -69,13 +69,13 @@ class SpellChecker:
     This loop is implemented using an iterator paradigm so it can be
     embedded inside other loops of control.
 
-    The SpellChecker object is stateful, and the appropriate methods
+    The `SpellChecker` object is stateful, and the appropriate methods
     must be called to alter its state and affect the progress of
     the spell checking session.  At any point during the checking
-    session, the attribute 'word' will hold the current erroneously
+    session, the attribute :py:attr:`word` will hold the current erroneously
     spelled word under consideration.  The action to take on this word
-    is determined by calling methods such as 'replace', 'replace_always'
-    and 'ignore_always'.  Once this is done, calling 'next' advances
+    is determined by calling methods such as :py:meth:`replace`, :py:meth:`replace_always`
+    and :py:meth:`ignore_always`.  Once this is done, calling :py:meth:`next` advances
     to the next misspelled word.
 
     As a quick (and rather silly) example, the following code replaces
@@ -90,22 +90,22 @@ class SpellChecker:
         'This is SPAM text with a SPAM SPAM errors in it.'
         >>>
 
-    Internally, the SpellChecker always works with arrays of (possibly
+    Internally, the `SpellChecker` always works with arrays of (possibly
     unicode) character elements.  This allows the in-place modification
     of the string as it is checked, and is the closest thing Python has
     to a mutable string.  The text can be set as any of a normal string,
     unicode string, character array or unicode character array. The
-    'get_text' method will return the modified array object if an
+    :py:meth:`get_text` method will return the modified array object if an
     array is used, or a new string object if a string it used.
 
-    Words input to the SpellChecker may be either plain strings or
+    Words input to the `SpellChecker` may be either plain strings or
     unicode objects.  They will be converted to the same type as the
     text being checked, using python's default encoding/decoding
     settings.
 
     If using an array of characters with this object and the
     array is modified outside of the spellchecking loop, use the
-    'set_offset' method to reposition the internal loop pointer
+    method :py:meth:`set_offset` to reposition the internal loop pointer
     to make sure it doesn't skip any words.
 
     """
@@ -120,22 +120,22 @@ class SpellChecker:
         chunkers: List[Chunker] = None,
         filters: List[Filter] = None,
     ) -> None:
-        """Constructor for the SpellChecker class.
+        """Constructor for the `SpellChecker` class.
 
-        SpellChecker objects can be created in two ways, depending on
+        `SpellChecker` objects can be created in two ways, depending on
         the nature of the first argument.  If it is a string, it
         specifies a language tag from which a dictionary is created.
-        Otherwise, it must be an enchant Dict object to be used.
+        Otherwise, it must be an :py:class:`enchant.Dict` object to be used.
 
         Optional keyword arguments are:
 
-            * text:  to set the text to be checked at creation time
-            * tokenize:  a custom tokenization function to use
-            * chunkers:  a list of chunkers to apply during tokenization
-            * filters:  a list of filters to apply during tokenization
+        :param text: to set the text to be checked at creation time
+        :param tokenize: a custom tokenization function to use
+        :param chunkers: a list of chunkers to apply during tokenization
+        :param filters: a list of filters to apply during tokenization
 
-        If <tokenize> is not given and the first argument is a Dict,
-        its 'tag' attribute must be a language tag so that a tokenization
+        If `tokenize` is not given and the first argument is a :py:class:`Dict`,
+        its `tag` attribute must be a language tag so that a tokenization
         function can be created automatically.  If this attribute is missing
         the user's default language will be used.
         """
@@ -183,8 +183,8 @@ class SpellChecker:
     def set_text(self, text: str) -> None:
         """Set the text to be spell-checked.
 
-        This method must be called, or the 'text' argument supplied
-        to the constructor, before calling the 'next()' method.
+        This method must be called, or the `text` argument supplied
+        to the constructor, before calling the method :py:meth:`next()`.
         """
         # Convert to an array object if necessary
         if isinstance(text, (str, bytes)):
@@ -213,8 +213,8 @@ class SpellChecker:
     def wants_unicode(self) -> bool:
         """Check whether the checker wants unicode strings.
 
-        This method will return True if the checker wants unicode strings
-        as input, False if it wants normal strings.  It's important to
+        This method will return `True` if the checker wants unicode strings
+        as input, `False` if it wants normal strings.  It's important to
         provide the correct type of string to the checker.
         """
         return self._text.typecode == "u"
@@ -248,12 +248,12 @@ class SpellChecker:
         """Process text up to the next spelling error.
 
         This method is designed to support the iterator protocol.
-        Each time it is called, it will advance the 'word' attribute
+        Each time it is called, it will advance the :py:attr:`word` attribute
         to the next spelling error in the text.  When no more errors
-        are found, it will raise StopIteration.
+        are found, it will raise :py:exc:`StopIteration`.
 
-        The method will always return self, so that it can be used
-        sensibly in common idioms such as:
+        The method will always return `self`, so that it can be used
+        sensibly in common idioms such as::
 
             for err in checker:
                 err.do_something()
@@ -355,13 +355,13 @@ class SpellChecker:
         """Set the offset of the tokenization routine.
 
         For more details on the purpose of the tokenization offset,
-        see the documentation of the 'enchant.tokenize' module.
-        The optional argument whence indicates the method by
+        see the documentation of the module :py:mod:`enchant.tokenize`.
+        The optional argument `whence` indicates the method by
         which to change the offset:
 
-            * 0 (the default) treats <off> as an increment
-            * 1 treats <off> as a distance from the start
-            * 2 treats <off> as a distance from the end
+            * 0 (the default) treats `off` as an increment
+            * 1 treats `off` as a distance from the start
+            * 2 treats `off` as a distance from the end
         """
         if whence == 0:
             self._tokens.set_offset(self._tokens.offset + off)
@@ -375,9 +375,9 @@ class SpellChecker:
             raise ValueError("Invalid value for whence: %s" % (whence,))
 
     def leading_context(self, chars: int) -> str:
-        """Get <chars> characters of leading context.
+        """Get `chars` characters of leading context.
 
-        This method returns up to <chars> characters of leading
+        This method returns up to `chars` characters of leading
         context - the text that occurs in the string immediately
         before the current erroneous word.
         """
@@ -386,9 +386,9 @@ class SpellChecker:
         return self._array_to_string(context)
 
     def trailing_context(self, chars: int) -> str:
-        """Get <chars> characters of trailing context.
+        """Get `chars` characters of trailing context.
 
-        This method returns up to <chars> characters of trailing
+        This method returns up to `chars` characters of trailing
         context - the text that occurs in the string immediately
         after the current erroneous word.
         """

--- a/enchant/checker/wxSpellCheckerDialog.py
+++ b/enchant/checker/wxSpellCheckerDialog.py
@@ -33,16 +33,16 @@
 
     enchant.checker.wxSpellCheckerDialog: wxPython spellchecker interface
 
-    This module provides the class wxSpellCheckerDialog, which provides
+    This module provides the class :py:class:`wxSpellCheckerDialog`, which provides
     a wxPython dialog that can be used as an interface to a spell checking
     session.  Currently it is intended as a proof-of-concept and demonstration
     class, but it should be suitable for general-purpose use in a program.
 
-    The class must be given an enchant.checker.SpellChecker object with
+    The class must be given an :py:class:`enchant.checker.SpellChecker` object with
     which to operate.  It can (in theory...) be used in modal and non-modal
-    modes.  Use Show() when operating on an array of characters as it will
+    modes.  Use `Show()` when operating on an array of characters as it will
     modify the array in place, meaning other work can be done at the same
-    time.  Use ShowModal() when operating on a static string.
+    time.  Use `ShowModal()` when operating on a static string.
 
 """
 _DOC_ERRORS = ["ShowModal"]
@@ -62,7 +62,7 @@ class wxSpellCheckerDialog(wx.Dialog):
     how to do this, although it should be useful for applications that
     just need a simple graphical spellchecker.
 
-    To use, a SpellChecker instance must be created and passed to the
+    To use, a :py:class:`SpellChecker` instance must be created and passed to the
     dialog before it is shown:
 
         >>> chkr = SpellChecker("en_AU",text)
@@ -72,7 +72,7 @@ class wxSpellCheckerDialog(wx.Dialog):
     This is most useful when the text to be checked is in the form of
     a character array, as it will be modified in place as the user
     interacts with the dialog.  For checking strings, the final result
-    will need to be obtained from the SpellChecker object:
+    will need to be obtained from the `SpellChecker` object:
 
         >>> chkr = SpellChecker("en_AU",text)
         >>> dlg = wxSpellCheckerDialog(chkr,None,-1,"")

--- a/enchant/pypwl.py
+++ b/enchant/pypwl.py
@@ -90,8 +90,8 @@ class Trie:
     def search(self, word: str, nerrs: int = 0) -> List[str]:
         """Search for the given word, possibly making errors.
 
-        This method searches the trie for the given <word>, making
-        precisely <nerrs> errors.  It returns a list of words found.
+        This method searches the trie for the given `word`, making
+        precisely `nerrs` errors.  It returns a list of words found.
         """
         res = []  # type: List[str]
         # Terminate if we've run out of errors
@@ -171,7 +171,7 @@ class PyPWL:
         will be read from this file, and new entries will be written to
         it automatically.
 
-        If <pwl> is not specified or None, the list is maintained in
+        If `pwl` is not specified or None, the list is maintained in
         memory only.
         """
         self.provider = None
@@ -192,7 +192,7 @@ class PyPWL:
         """Check spelling of a word.
 
         This method takes a word in the dictionary language and returns
-        True if it is correctly spelled, and false otherwise.
+        `True` if it is correctly spelled, and `False` otherwise.
         """
         res = self._words.search(word)
         return bool(res)
@@ -256,9 +256,9 @@ class PyPWL:
         """Store a replacement spelling for a miss-spelled word.
 
         This method makes a suggestion to the spellchecking engine that the
-        miss-spelled word <mis> is in fact correctly spelled as <cor>.  Such
-        a suggestion will typically mean that <cor> appears early in the
-        list of suggested spellings offered for later instances of <mis>.
+        miss-spelled word `mis` is in fact correctly spelled as `cor`.  Such
+        a suggestion will typically mean that `cor` appears early in the
+        list of suggested spellings offered for later instances of `mis`.
         """
         # Too much work for this simple spellchecker
         pass

--- a/enchant/tokenize/__init__.py
+++ b/enchant/tokenize/__init__.py
@@ -43,20 +43,20 @@ form, one for each word found::
 
     (<word>,<pos>)
 
-The meanings of these fields should be clear: <word> is the word
-that was found and <pos> is the position within the text at which
+The meanings of these fields should be clear: `word` is the word
+that was found and `pos` is the position within the text at which
 the word began (zero indexed, of course).  The function will work
 on any string-like object that supports array-slicing; in particular
-character-array objects from the 'array' module may be used.
+character-array objects from the :py:mod:`array` module may be used.
 
-The iterator also provides the attribute 'offset' which gives the current
+The iterator also provides the attribute :py:attr:`~.tokenize.offset` which gives the current
 position of the tokenizer inside the string being split, and the method
-'set_offset' for manually adjusting this position.  This can be used for
+:py:meth:`~tokenize.set_offset` for manually adjusting this position.  This can be used for
 example if the string's contents have changed during the tokenization
 process.
 
 To obtain an appropriate tokenization function for the language
-identified by <tag>, use the function 'get_tokenizer(tag)'::
+identified by `tag`, use the function :py:func:`get_tokenizer`::
 
     tknzr = get_tokenizer("en_US")
     for (word,pos) in tknzr("text to be tokenized goes here")
@@ -64,8 +64,8 @@ identified by <tag>, use the function 'get_tokenizer(tag)'::
 
 This library is designed to be easily extendible by third-party
 authors.  To register a tokenization function for the language
-<tag>, implement it as the function 'tokenize' within the
-module enchant.tokenize.<tag>.  The 'get_tokenizer' function
+`tag`, implement it as the function `tokenize` within the
+module `enchant.tokenize.<tag>`.  The function :py:func:`get_tokenizer`
 will automatically detect it.  Note that the underscore must be
 used as the tag component separator in this case, in order to
 form a valid python module name. (e.g. "en_US" rather than "en-US")
@@ -74,16 +74,16 @@ Currently, a tokenizer has only been implemented for the English
 language.  Based on the author's limited experience, this should
 be at least partially suitable for other languages.
 
-This module also provides various implementations of "Chunkers" and
-"Filters".  These classes are designed to make it easy to work with
+This module also provides various implementations of Chunkers and
+Filters.  These classes are designed to make it easy to work with
 text in a variety of common formats, by detecting and excluding parts
 of the text that don't need to be checked.
 
-A Chunker is a class designed to break a body of text into large chunks
-of checkable content; for example the HTMLChunker class extracts the
+A :py:class:`Chunker` is a class designed to break a body of text into large chunks
+of checkable content; for example the :py:class:`HTMLChunker` class extracts the
 text content from all HTML tags but excludes the tags themselves.
-A Filter is a class designed to skip individual words during the checking
-process; for example the URLFilter class skips over any words that
+A :py:class:`Filter` is a class designed to skip individual words during the checking
+process; for example the :py:class:`URLFilter` class skips over any words that
 have the format of a URL.
 
 For example, to spellcheck an HTML document it is necessary to split the
@@ -126,7 +126,7 @@ Error = TokenizerNotFoundError
 class tokenize:  # noqa: N801
     """Base class for all tokenizer objects.
 
-    Each tokenizer must be an iterator and provide the 'offset'
+    Each tokenizer must be an iterator and provide the :py:attr:`offset`
     attribute as described in the documentation for this module.
 
     While tokenizers are in fact classes, they should be treated
@@ -157,8 +157,8 @@ class tokenize:  # noqa: N801
 
     def _set_offset(self, offset: int) -> None:
         msg = (
-            "changing a tokenizers 'offset' attribute is deprecated;"
-            " use the 'set_offset' method"
+            "changing a tokenizers :py:attr:`offset` attribute is deprecated;"
+            " use the :py:meth:`set_offset` method"
         )
         warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
         self.set_offset(offset)
@@ -173,20 +173,20 @@ def get_tokenizer(
 ) -> tokenize:
     """Locate an appropriate tokenizer by language tag.
 
-    This requires importing the function 'tokenize' from an appropriate
+    This requires importing the function `tokenize` from an appropriate
     module.  Modules tried are named after the language tag, tried in the
     following order:
 
         * the entire tag (e.g. "en_AU.py")
         * the base country code of the tag (e.g. "en.py")
 
-    If the language tag is None, a default tokenizer (actually the English
+    If the language tag is `None`, a default tokenizer (actually the English
     one) is returned.  It's unicode aware and should work OK for most
     latin-derived languages.
 
-    If a suitable function cannot be found, raises TokenizerNotFoundError.
+    If a suitable function cannot be found, raises :py:exc:`~.errors.TokenizerNotFoundError`.
 
-    If given and not None, 'chunkers' and 'filters' must be lists of chunker
+    If given and not `None`, `chunkers` and `filters` must be lists of chunker
     classes and filter classes respectively.  These will be applied to the
     tokenizer during creation.
     """
@@ -331,9 +331,9 @@ _Filter = Union[Type[tokenize], "Filter"]
 def wrap_tokenizer(tk1: _Filter, tk2: _Filter) -> "Filter":
     """Wrap one tokenizer inside another.
 
-    This function takes two tokenizer functions 'tk1' and 'tk2',
+    This function takes two tokenizer functions `tk1` and `tk2`,
     and returns a new tokenizer function that passes the output
-    of tk1 through tk2 before yielding it to the calling code.
+    of `tk1` through `tk2` before yielding it to the calling code.
     """
     # This logic is already implemented in the Filter class.
     # We simply use tk2 as the _split() method for a filter
@@ -359,15 +359,15 @@ class Chunker(tokenize):
 class Filter:
     """Base class for token filtering functions.
 
-    A filter is designed to wrap a tokenizer (or another filter) and do
+    A filter is designed to wrap a tokenizer (or another :py:class:`Filter`) and do
     two things:
 
       * skip over tokens
       * split tokens into sub-tokens
 
     Subclasses have two basic options for customising their behaviour.  The
-    method _skip(word) may be overridden to return True for words that
-    should be skipped, and false otherwise.  The method _split(word) may
+    method :py:meth:`_skip` may be overridden to return `True` for words that
+    should be skipped, and `False` otherwise.  The method :py:meth:`_split` may
     be overridden as tokenization function that will be applied to further
     tokenize any words that aren't skipped.
     """
@@ -383,7 +383,7 @@ class Filter:
     def _skip(self, word: str) -> bool:
         """Filter method for identifying skippable tokens.
 
-        If this method returns true, the given word will be skipped by
+        If this method returns `True`, the given word will be skipped by
         the filter.  This should be overridden in subclasses to produce the
         desired functionality.  The default behaviour is not to skip any words.
         """
@@ -402,7 +402,7 @@ class Filter:
         """Private inner class implementing the tokenizer-wrapping logic.
 
         This might seem convoluted, but we're trying to create something
-        akin to a meta-class - when Filter(tknzr) is called it must return
+        akin to a meta-class - when `Filter(tknzr)` is called it must return
         a *callable* that can then be applied to a particular string to
         perform the tokenization.  Since we need to manage a lot of state
         during tokenization, returning a class is the best option.

--- a/enchant/tokenize/en.py
+++ b/enchant/tokenize/en.py
@@ -54,10 +54,10 @@ class tokenize(enchant.tokenize.tokenize):  # noqa: N801
 
         (<word>,<pos>)
 
-    Where <word> is the word string found and <pos> is the position
+    Where `word` is the word string found and `pos` is the position
     of the start of the word within the text.
 
-    The optional argument <valid_chars> may be used to specify a
+    The optional argument `valid_chars` may be used to specify a
     list of additional characters that can form part of a word.
     By default, this list contains only the apostrophe ('). Note that
     these characters cannot appear at the start or end of a word.

--- a/enchant/utils.py
+++ b/enchant/utils.py
@@ -52,7 +52,7 @@ from enchant.errors import Error
 def levenshtein(s1: str, s2: str) -> int:
     """Calculate the Levenshtein distance between two strings.
 
-    This is straight from Wikipedia.
+    This is straight from `Wikipedia <https://en.wikipedia.org/wiki/Levenshtein_distance>`_.
     """
     if len(s1) < len(s2):
         return levenshtein(s2, s1)

--- a/enchant/utils.py
+++ b/enchant/utils.py
@@ -84,7 +84,7 @@ def trim_suggestions(
     to trim it down to a maximum length.  It tries to keep the "best"
     suggestions based on similarity to the original word.
 
-    If the optional "calcdist" argument is provided, it must be a callable
+    If the optional `calcdist` argument is provided, it must be a callable
     taking two words and returning the distance between them.  It will be
     used to determine which words to retain in the list.  The default is
     a simple Levenshtein distance.
@@ -99,15 +99,15 @@ def trim_suggestions(
 def get_default_language(default: Optional[str] = None) -> Optional[str]:
     """Determine the user's default language, if possible.
 
-    This function uses the 'locale' module to try to determine
+    This function uses the :py:mod:`locale` module to try to determine
     the user's preferred language.  The return value is as
     follows:
 
-        * if a locale is available for the LC_MESSAGES category,
+        * if a locale is available for the `LC_MESSAGES` category,
           that language is used
         * if a default locale is available, that language is used
-        * if the keyword argument <default> is given, it is used
-        * if nothing else works, None is returned
+        * if the keyword argument `default` is given, it is used
+        * if nothing else works, `None` is returned
 
     Note that determining the user's language is in general only
     possible if they have set the necessary environment variables

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -70,6 +70,10 @@ WORDS = [
     "runtime",
     "py",
     "meth",
+    "attr",
+    "func",
+    "exc",
+    "enchant",
 ]
 
 

--- a/website/content/api/enchant.errors.rst
+++ b/website/content/api/enchant.errors.rst
@@ -1,0 +1,4 @@
+
+.. automodule:: enchant.errors
+   :members:
+

--- a/website/content/api/index.rst
+++ b/website/content/api/index.rst
@@ -16,6 +16,7 @@ By module
 
    enchant.rst
    enchant.checker.rst
+   enchant.errors.rst
    enchant.tokenize.rst
    enchant.utils.rst
    enchant.pypwl.rst

--- a/website/content/tutorial.rst
+++ b/website/content/tutorial.rst
@@ -25,7 +25,7 @@ When the current language can be determined, it operates as follows::
   >>> d = enchant.Dict()
   >>> d.tag
   'en_AU'
-  >>> print d.tag
+  >>> print(d.tag)
   en_AU
 
 Of course, this may still fail if the appropriate dictionary is not available. If it cannot be determined, the behavior is as follows::
@@ -98,7 +98,7 @@ SpellChecker objects are created in the same way as Dict objects - by passing a 
   >>> chkr = SpellChecker("en_US")
   >>> chkr.set_text("This is sme sample txt with erors.")
   >>> for err in chkr:
-  ...     print "ERROR:", err.word
+  ...     print("ERROR:", err.word)
   ...
   ERROR: sme
   ERROR: txt

--- a/website/content/tutorial.rst
+++ b/website/content/tutorial.rst
@@ -9,7 +9,7 @@ Once installed, PyEnchant's functionality is available in the "enchant" module.
 Creating and Using Dictionary Objects
 ++++++++++++++++++++++++++++++++++++++
 
-The most important object in the PyEnchant module is the Dict object, which represents a dictionary. These objects are used to check the spelling of words and to get suggestions for misspelled words. The following shows how to construct a simple Dict and use it to check some words::
+The most important object in the PyEnchant module is the Dict object, which represents a dictionary. These objects are used to check the spelling of words and to get suggestions for misspelled words. The following shows how to construct a simple :py:class:`~enchant.Dict` and use it to check some words::
 
     >>> import enchant
     >>> d = enchant.Dict("en_US")
@@ -40,9 +40,9 @@ Of course, this may still fail if the appropriate dictionary is not available. I
 
 There are several top-level functions in the enchant module which can be used to deal with dictionaries:
 
-    * dict_exists: Check whether a Dict is available for a given language
-    * request_dict: Construct and return a new Dict object
-    * list_languages: List the languages for which Dicts are available
+    * :py:func:`~enchant.dict_exists`: Check whether a Dict is available for a given language
+    * :py:func:`~enchant.request_dict`: Construct and return a new Dict object
+    * :py:func:`~enchant.list_languages`: List the languages for which Dicts are available
 
 ::
 
@@ -56,19 +56,19 @@ There are several top-level functions in the enchant module which can be used to
   >>> enchant.list_languages()
   ['en', 'en_CA', 'en_GB', 'en_US', 'eo', 'fr', 'fr_CH', 'fr_FR']
 
-As shown previously, the check method of a Dict object can be used to check whether a word is correctly spelled. To get suggestions for a misspelled word, use the suggest method as shown below::
+As shown previously, the method :py:meth:`~enchant.Dict.check` can be used to check whether a word is correctly spelled. To get suggestions for a misspelled word, use the suggest method as shown below::
 
   >>> d.suggest("Helo")
   ['He lo', 'He-lo', 'Hello', 'Helot', 'Help', 'Halo', 'Hell', 'Held', 'Helm', 'Hero', "He'll"]
 
 The suggestions are returned in a list, ordered from most likely replacement to least likely.
 
-Once a correction is made to a miss-spelled word, it is often useful to store this correction in some way for later use. The Dict object provides several methods to handle this:
+Once a correction is made to a miss-spelled word, it is often useful to store this correction in some way for later use. The :py:class:`~enchant.Dict` object provides several methods to handle this:
 
-    * add: store an unrecognised word in the user's personal dictionary so that it is recognised as correct in the future.
-    * remove: store a recognised word in the user's personal exclude list, so that it is identified as an error in the future.
-    * add_to_session: store an unrecognised word so that it will be recognised as correct while the Dict object is still in use.
-    * store_replacement: note that one word was used to replace another, meaning that it will appear higher in the list of suggestions in the future.
+    * :py:meth:`~enchant.Dict.add`: store an unrecognised word in the user's personal dictionary so that it is recognised as correct in the future.
+    * :py:meth:`~enchant.Dict.remove`: store a recognised word in the user's personal exclude list, so that it is identified as an error in the future.
+    * :py:meth:`~enchant.Dict.add_to_session`: store an unrecognised word so that it will be recognised as correct while the Dict object is still in use.
+    * :py:meth:`~enchant.Dict.store_replacement`: note that one word was used to replace another, meaning that it will appear higher in the list of suggestions in the future.
 
 
 Personal Word Lists
@@ -80,7 +80,7 @@ Dict objects can also be used to check words against a custom list of correctly-
 
 The personal word list Dict object can be used in the same way as Dict objects which reference a language dictionary. When the object's add method is called, new entries will be appended to the bottom of the file.
 
-PyEnchant also provides the class DictWithPWL which can be used to combine a language dictionary and a personal word list file::
+PyEnchant also provides the class :py:class:`~enchant.DictWithPWL` which can be used to combine a language dictionary and a personal word list file::
 
   >>> d2 = enchant.DictWithPWL("en_US","mywords.txt")
   >>> d2.check("Hello")
@@ -90,9 +90,9 @@ PyEnchant also provides the class DictWithPWL which can be used to combine a lan
 Checking entire blocks of text
 ++++++++++++++++++++++++++++++
 
-While the enchant.Dict objects are useful for spellchecking individual words, they cannot be used directly to check, for example, an entire paragraph. The module enchant.checker provides a class SpellChecker which is designed to handle this task.
+While the :py:class:`enchant.Dict` objects are useful for spellchecking individual words, they cannot be used directly to check, for example, an entire paragraph. The module :py:mod:`enchant.checker` provides a class :py:class:`~enchant.checker.SpellChecker` which is designed to handle this task.
 
-SpellChecker objects are created in the same way as Dict objects - by passing a language tag to the constructor. The set_text method is used to set the text which is to be checked. Once this is done, the SpellChecker object can be used as an iterator over the spelling mistakes in the text. This is best illustrated by a simple example. The following code will print out the errors encountered in a string::
+`SpellChecker` objects are created in the same way as `Dict` objects - by passing a language tag to the constructor. The method :py:meth:`~enchant.checker.SpellChecker.set_text` is used to set the text which is to be checked. Once this is done, the SpellChecker object can be used as an iterator over the spelling mistakes in the text. This is best illustrated by a simple example. The following code will print out the errors encountered in a string::
 
   >>> from enchant.checker import SpellChecker
   >>> chkr = SpellChecker("en_US")
@@ -104,7 +104,7 @@ SpellChecker objects are created in the same way as Dict objects - by passing a 
   ERROR: txt
   ERROR: erors
 
-The SpellChecker can use filters to ignore certain word forms, by passing a list of filters in as a keyword argument::
+The `SpellChecker` can use filters to ignore certain word forms, by passing a list of filters in as a keyword argument::
 
   >>> from enchant.checker import SpellChecker
   >>> from enchant.tokenize import EmailFilter, URLFilter
@@ -116,7 +116,7 @@ The iterator paradigm can be used to implement a wide variety of spellchecking f
 wxSpellCheckerDialog
 ++++++++++++++++++++
 
-The module enchant.checker.wxSpellCheckerDialog provides the class wxSpellCheckerDialog which can be used to interactively check the spelling of some text. The code below shows how to create and use such a dialog from within a wxPython application.
+The module :py:mod:`enchant.checker.wxSpellCheckerDialog` provides the class :py:class:`~enchant.checker.wxSpellCheckerDialog.wxSpellCheckerDialog` which can be used to interactively check the spelling of some text. The code below shows how to create and use such a dialog from within a wxPython application.
 
 It will pop up a simple spellchecking dialog like the one shown here. Each spelling error is highlighted in turn, with the buttons offering a range of options for how to deal with the error:
 
@@ -144,7 +144,7 @@ It will pop up a simple spellchecking dialog like the one shown here. Each spell
 CmdLineChecker
 ++++++++++++++
 
-The module enchant.checker.CmdLineChecker provides the class CmdLineChecker which can be used to interactively check the spelling of some text. It uses standard input and standard output to interact with the user through a command-line interface. The code below shows how to create and use this class from within a python application, along with a short sample checking session::
+The module :py:mod:`enchant.checker.CmdLineChecker` provides the class :py:class:`~enchant.checker.CmdLineChecker.CmdLineChecker` which can be used to interactively check the spelling of some text. It uses standard input and standard output to interact with the user through a command-line interface. The code below shows how to create and use this class from within a python application, along with a short sample checking session::
 
   >>> import enchant
   >>> import enchant.checker
@@ -177,13 +177,13 @@ The module enchant.checker.CmdLineChecker provides the class CmdLineChecker whic
   >>> chkr.get_text()
   'this is some example txt'
 
-As shown by this simple example, the CmdLineChecker prints each error it encounters, along with a list of suggested replacements. The user enters the desired behavior using short alphanumeric commands, as explained by the output of the 'help' command.
+As shown by this simple example, the `CmdLineChecker` prints each error it encounters, along with a list of suggested replacements. The user enters the desired behavior using short alphanumeric commands, as explained by the output of the 'help' command.
 
 
 Tokenization: splitting text into words
 +++++++++++++++++++++++++++++++++++++++
 
-An important task in spellchecking is splitting a body of text up into its constitutive words, each of which is then passed to a Dict object for checking. PyEnchant provides the enchant.tokenize module to assist with this task. The purpose of this module is to provide an appropriate tokenization function which can be used to split the text. Usually, all that is required is the get_tokenizer function::
+An important task in spellchecking is splitting a body of text up into its constitutive words, each of which is then passed to a :py:class:`~enchant.Dict` object for checking. PyEnchant provides the :py:mod:`enchant.tokenize` module to assist with this task. The purpose of this module is to provide an appropriate tokenization function which can be used to split the text. Usually, all that is required is the function :py:func:`~enchant.tokenize.get_tokenizer`::
 
   >>> from enchant.tokenize import get_tokenizer
   >>> tknzr = get_tokenizer("en_US")
@@ -192,9 +192,9 @@ An important task in spellchecking is splitting a body of text up into its const
   >>> [w for w in tknzr("this is some simple text")]
   [('this', 0), ('is', 5), ('some', 8), ('simple', 13), ('text', 20)]
 
-As shown in the example above, the function get_tokenizer takes a language tag as input, and returns a tokenization class that is appropriate for that language. Instantiating this class with some text returns an iterator which will yield the words contained in that text. This is exactly the mechanism that the SpellChecker class uses internally to split text into a series of words.
+As shown in the example above, the function :py:func:`~enchant.tokenize.get_tokenizer` takes a language tag as input, and returns a tokenization class that is appropriate for that language. Instantiating this class with some text returns an iterator which will yield the words contained in that text. This is exactly the mechanism that the class :py:class:`enchant.tokenize.SpellChecker` uses internally to split text into a series of words.
 
-The items produced by the tokenizer are tuples of the form (WORD,POS) where WORD is the word which was found and POS is the position within the string at which that word begins.
+The items produced by the tokenizer are tuples of the form `(WORD,POS)` where `WORD` is the word which was found and `POS` is the position within the string at which that word begins.
 
 
 Chunkers
@@ -202,7 +202,7 @@ Chunkers
 
 In many applications, checkable text may be intermingled with some sort of markup (e.g. HTML tags) which does not need to be checked. To have the tokenizer return only those words that should be checked, it can be augmented with one or more chunkers.
 
-A chunker is simply a special tokenizer function that breaks text up into large chunks rather than individual tokens. They are typically used by passing a list of chunkers to the get_tokenizer function::
+A chunker is simply a special tokenizer function that breaks text up into large chunks rather than individual tokens. They are typically used by passing a list of chunkers to the function :py:func:`~enchant.tokenize.get_tokenizer`::
 
   >>> from enchant.tokenize import get_tokenizer, HTMLChunker
   >>>
@@ -216,9 +216,9 @@ A chunker is simply a special tokenizer function that breaks text up into large 
   [('this', 0), ('is', 5), ('really', 32), ('important', 39), ('text', 56)]
 
 
-When the HTMLChunker is applied to the tokenizer, the <span> tag and its contents are removed from the list of words.
+When the :py:class:`~enchant.tokenize.HTMLChunker` is applied to the tokenizer, the <span> tag and its contents are removed from the list of words.
 
-Currently the only implemented chunker is HTMLChunker. A chunker for LaTeX documents is in the works.
+Currently the only implemented chunker is :py:class:`~enchant.tokenize.HTMLChunker`. A chunker for LaTeX documents is in the works.
 
 
 Filters
@@ -226,7 +226,7 @@ Filters
 
 In many applications, it is common for spellchecking to ignore words that have a certain form. For example, when spellchecking an email it is customary to ignore email addresses and URLs. This can be achieved by augmenting the tokenization process with filters.
 
-A filter is simply a wrapper around a tokenizer that can (1) drop certain words from the stream, and (2) further split words into sub-tokens. They are typically used by passing a list of filters to the get_tokenizer function::
+A filter is simply a wrapper around a tokenizer that can (1) drop certain words from the stream, and (2) further split words into sub-tokens. They are typically used by passing a list of filters to the function :py:func:`~enchant.tokenize.get_tokenizer`::
 
   >>> from enchant.tokenize import get_tokenizer, EmailFilter
   >>>
@@ -238,9 +238,9 @@ A filter is simply a wrapper around a tokenizer that can (1) drop certain words 
   >>> [w for w in tknzr("send an email to fake@example.com please")]
   [('send', 0), ('an', 5), ('email', 8), ('to', 14), ('please', 34)]
 
-When the EmailFilter is applied to the tokenizer, the email address is removed from the list of words.
+When the :py:class:`~enchant.tokenize.EmailFilter` is applied to the tokenizer, the email address is removed from the list of words.
 
-Currently implemented filters are EmailFilter, URLFilter and WikiWordFilter.
+Currently implemented filters are :py:class:`~enchant.tokenize.EmailFilter`, :py:class:`~enchant.tokenize.URLFilter` and :py:class:`~enchant.tokenize.WikiWordFilter`.
 
 
 Advanced PyEnchant Usage
@@ -253,7 +253,7 @@ The underlying programming model provided by the Enchant library is based on the
 
 In this way, enchant forms a "wrapper" around existing spellchecking tools in order to provide a common programming interface.
 
-The provider which is managing a particular Dict object can be determined by accessing its provider attribute. This is a ProviderDesc object with the properties name, desc and file::
+The provider which is managing a particular :py:class:`~enchant.Dict` object can be determined by accessing its provider attribute. This is a :py:class:`~enchant.ProviderDesc` object with the properties :py:attr:`~enchant.ProviderDesc.name`, :py:attr:`~enchant.ProviderDesc.desc` and :py:attr:`~enchant.ProviderDesc.file`::
 
   >>> d = enchant.Dict("en_US")
   >>> d.provider <Enchant: Aspell Provider>
@@ -268,7 +268,7 @@ The provider which is managing a particular Dict object can be determined by acc
 Brokers
 +++++++
 
-The details of which provider is used to create a particular dictionary are managed by a Broker object. Such objects have methods for creating dictionaries and checking whether a particular dictionary exists, as shown in the example below::
+The details of which provider is used to create a particular dictionary are managed by a :py:class:`~enchant.Broker` object. Such objects have methods for creating dictionaries and checking whether a particular dictionary exists, as shown in the example below::
 
   >>> b = enchant.Broker()
   >>> b
@@ -283,7 +283,7 @@ The details of which provider is used to create a particular dictionary are mana
   >>> d
   <enchant.Dict object at 0x2aaaabdff8d0>
 
-Brokers also have the method describe which determines which providers are available, and the method list_dicts which lists the dictionaries available through each provider::
+Brokers also have the method :py:meth:`~enchant.Broker.describe` which determines which providers are available, and the method :py:meth:`~enchant.Broker.list_dicts` which lists the dictionaries available through each provider::
 
   >>> b = enchant.Broker()
   >>> b.describe()
@@ -295,7 +295,7 @@ Brokers also have the method describe which determines which providers are avail
 The Default Broker
 ~~~~~~~~~~~~~~~~~~
 
-In normal use, the functionality provided by brokers is not useful to the programmer. To make the programmer's job easier, PyEnchant creates a default Broker object and uses it whenever one is not explicitly given. For example, the default broker is used when creating dictionary objects directly. This object is available as enchant._broker::
+In normal use, the functionality provided by brokers is not useful to the programmer. To make the programmer's job easier, PyEnchant creates a default :py:class:`~enchant.Broker` object and uses it whenever one is not explicitly given. For example, the default broker is used when creating dictionary objects directly. This object is available as :py:data:`enchant._broker`::
 
   >>> enchant._broker
   <enchant.Broker object at 0x2aaaabdff590>
@@ -303,7 +303,7 @@ In normal use, the functionality provided by brokers is not useful to the progra
   >>> d._broker
   <enchant.Broker object at 0x2aaaabdff590>
 
-You may have noticed that the top-level functions provided by the enchant module (such as request_dict, dict_exists and list_languages) match the methods provided by the Broker class. These functions are in fact the instance methods of the default Broker object::
+You may have noticed that the top-level functions provided by the enchant module (such as :py:func:`~enchant.request_dict`, :py:func:`~enchant.dict_exists` and :py:func:`~enchant.list_languages`) match the methods provided by the :py:class:`~enchant.Broker` class. These functions are in fact the instance methods of the default :py:class:`~enchant.Broker` object::
 
   >>> enchant._broker
   <enchant.Broker object at 0x2aaaabdff590>
@@ -318,7 +318,7 @@ You may have noticed that the top-level functions provided by the enchant module
 Provider Ordering
 ~~~~~~~~~~~~~~~~~
 
-Which provider is used for which language is determined by the provider ordering of the Broker. This can be altered using the set_ordering method. This method accepts a language tag and a comma-separated list of provider names in the order that they should be checked. A language tag of "*" means that the ordering should be the default for all languages where an explicit ordering has not been given.
+Which provider is used for which language is determined by the provider ordering of the :py:class:`~enchant.Broker`. This can be altered using the method :py:meth:`~enchant.Broker.set_ordering`. This method accepts a language tag and a comma-separated list of provider names in the order that they should be checked. A language tag of "*" means that the ordering should be the default for all languages where an explicit ordering has not been given.
 
 The following example states that for American English the MySpell provider should be tried first, followed by the aspell provider. For all other languages, the ordering is reversed::
 
@@ -336,8 +336,8 @@ The user can also set their preferred ordering using enchant configuration files
 Extending enchant.tokenize
 ++++++++++++++++++++++++++
 
-As explained above, the module enchant.tokenize provides the ability to split text into its component words. The current implementation is based only on the rules for the English language, and so might not be completely suitable for your language of choice. Fortunately, it is straightforward to extend the functionality of this module.
+As explained above, the module :py:mod:`enchant.tokenize` provides the ability to split text into its component words. The current implementation is based only on the rules for the English language, and so might not be completely suitable for your language of choice. Fortunately, it is straightforward to extend the functionality of this module.
 
-To implement a new tokenization routine for the language TAG, simply create a class/function "tokenize" within the module "enchant.tokenize.TAG". This function will automatically be detected by the module's get_tokenizer function and used when appropriate. The easiest way to accomplish this is to copy the module "enchant.tokenize.en" and modify it to suit your needs.
+To implement a new tokenization routine for the language `TAG`, simply create a class/function `tokenize` within the module `enchant.tokenize.<TAG>`. This function will automatically be detected by the module's function :py:func:`~enchant.tokenize.get_tokenizer` and used when appropriate. The easiest way to accomplish this is to copy the module :py:mod:`enchant.tokenize.en` and modify it to suit your needs.
 
 The author would be very grateful for tokenization routines for languages other than English which can be incorporated back into the main PyEnchant distribution.


### PR DESCRIPTION
Improve the Sphinx generated documentation by providing direct links to API.

- cf9b661 doc: Convert to Sphinx reStructuredText
- 54bc8b0 doc[utils]: Add Wikipedia link for Levenshtein
- d3c5c81 doc[tutorial]: Convert to Python 3 print function
- a951a8c doc: Add enchant.errors
