### PR TITLE
Add support for detecting Homebrew on M1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev", "pypy-3.8"]
         include:
          - python: "3.7"
            tox_env: "py37"
@@ -24,6 +24,10 @@ jobs:
            tox_env: "py39"
          - python: "3.10"
            tox_env: "py310"
+         - python: "3.11"
+           tox_env: "py312"
+         - python: "3.12-dev"
+           tox_env: "py312"
          - python: "pypy-3.8"
            tox_env: "pypy3"
          - os: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
          - python: "3.10"
            tox_env: "py310"
          - python: "3.11"
-           tox_env: "py312"
+           tox_env: "py311"
          - python: "3.12-dev"
            tox_env: "py312"
          - python: "pypy-3.8"
@@ -46,7 +46,7 @@ jobs:
     - name: Install libenchant-dev (linux)
       if: matrix.platform == 'linux'
       run: |
-        sudo apt install libenchant-dev
+        sudo apt install libenchant-2-dev
 
     - name: Install enchant (macOS)
       if: matrix.platform == 'macos'

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 build/
 dist/
 *.egg-info
+venv
 .tox
 .coverage*
 htmlcov

--- a/enchant/_enchant.py
+++ b/enchant/_enchant.py
@@ -109,6 +109,14 @@ def from_system() -> Optional[str]:
         "libenchant-1",
     ]
 
+    # On M1 macs, Homebrew is in /opt, which isn't on the default
+    # DYLD_LIBRARY_PATH. Look for the homebrew path explicitly.
+    if sys.platform == "darwin" and platform.machine() == "arm64":
+        candidates.extend([
+            f"/opt/homebrew/lib/{candidate}"
+            for candidate in candidates
+        ])
+
     for name in candidates:
         find_message("with name ", name)
         res = ctypes.util.find_library(name)

--- a/enchant/_enchant.py
+++ b/enchant/_enchant.py
@@ -112,10 +112,9 @@ def from_system() -> Optional[str]:
     # On M1 macs, Homebrew is in /opt, which isn't on the default
     # DYLD_LIBRARY_PATH. Look for the homebrew path explicitly.
     if sys.platform == "darwin" and platform.machine() == "arm64":
-        candidates.extend([
-            f"/opt/homebrew/lib/{candidate}"
-            for candidate in candidates
-        ])
+        candidates.extend(
+            [f"/opt/homebrew/lib/{candidate}" for candidate in candidates]
+        )
 
     for name in candidates:
         find_message("with name ", name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
   Programming Language :: Python :: Implementation :: CPython
   Programming Language :: Python :: Implementation :: PyPy
   Topic :: Software Development :: Libraries

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,py3}
+envlist = py{37,38,39,310,311,312,py3}
 skip_missing_interpreters = true
 
 [testenv]

--- a/website/content/install.rst
+++ b/website/content/install.rst
@@ -56,37 +56,8 @@ The quickest way is to install `libenchant` using `Homebrew <https://brew.sh/>`_
     brew update
     brew install enchant
 
-Apple Silicon related errors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you get this error:
-``The 'enchant' C library was not found and maybe needs to be installed.``,
-as a workaround, you may need to install an ``x86_64`` (Intel) version of ``enchant``.
-In order to do so, you need to install the ``x86_64`` version of Homebrew in
-``/usr/local/`` and then use this version to install the corresponding
-version of ``enchant``.
-
-.. code-block:: bash
-
-    arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    arch -x86_64 /usr/local/bin/brew install enchant
-    
-If you get this error:
-``[...] (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), [...]``
-This means that you are mixing architectures (the ``arm64`` native one with architecture and the ``x86_64`` architecture emulated by Rosetta2) between the ``libenchant`` (installed with Homebrew) and your python interpreter that ``import enchant``. This can happen if you keep parallel python environments for different architecures.
-
-If you are using ``conda`` environments , please note that the ``pyenchant`` cannot yet be installed via ``conda`` on MacOS (see `this comment <https://github.com/pyenchant/pyenchant/issues/279#issuecomment-1047079747>`_). You'll have to install it via ``pip``, and it causes some troubles if you are in a ``arm64`` ``conda`` environment.
-If you installed Python using ``conda``, it won't find the ``enchant`` C library because it won't look under the native library homebrew installation folder (``/opt/homebrew/lib/``) where it was installed via ``brew install enchant``.
-There are 3 workarounds to this problem:
-
-* set the environment variable ``PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.2.dylib`` or
-* set the environment variable ``DYLD_LIBRARY_PATH=/opt/homebrew/lib/`` or
-* use the python installed with ``homebrew`` (``/opt/homebrew/Cellar/python@<version>``) instead of the one installed by ``conda``, but you lose the benefit of using different python versions in different environments.
-
-Refer to the comments in `this issue <https://github.com/pyenchant/pyenchant/issues/265>`_ for a more detailled description of some of the issues related to Apple Silicon.
-
 MacPorts
-~~~~~~~~~~~
+~~~~~~~~
 
 If you are using `MacPorts <https://www.macports.org/>`_ you can also
 install the `enchant2 <https://github.com/macports/macports-


### PR DESCRIPTION
#265 added documentation for how to work around the change in location of Homebrew on M1 Macs. 

This PR removes the need for that workaround, by explicitly adding the Homebrew path to the list of lookup locations.

It also adds Python 3.11 and Python3.12 prereleases to the CI matrix.