### PR TITLE
Update README.rst to link to the Enchant website's new location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ languages.
 
 More information is available on the Enchant website:
 
-    https://abiword.github.io/enchant/
+    https://rrthomas.github.io/enchant/
 
 
 How do I use PyEnchant ?


### PR DESCRIPTION
The old location is a 404