### PR TITLE
Avoid deprecated checker unicode arrays

### DIFF
--- a/enchant/checker/__init__.py
+++ b/enchant/checker/__init__.py
@@ -57,8 +57,17 @@ from enchant.errors import (
     DictNotFoundError,
     TokenizerNotFoundError,
 )
-from enchant.tokenize import Chunker, Filter, get_tokenizer, tokenize
+from enchant.tokenize import (
+    _UNICODE_ARRAY_TYPECODES,
+    Chunker,
+    Filter,
+    get_tokenizer,
+    tokenize,
+)
 from enchant.utils import get_default_language
+
+# Python 3.13 added "w" as the non-deprecated replacement for "u".
+_UNICODE_ARRAY_TYPECODE = "w" if "w" in array.typecodes else "u"
 
 
 class SpellChecker:
@@ -169,7 +178,7 @@ class SpellChecker:
         self._ignore_words = {}
         self._replace_words = {}
         # Default to the empty string as the text to be checked
-        self._text = array.array("u")
+        self._text = array.array(_UNICODE_ARRAY_TYPECODE)
         self._use_tostring = False
         self._tokens = iter([])
 
@@ -189,7 +198,7 @@ class SpellChecker:
         # Convert to an array object if necessary
         if isinstance(text, (str, bytes)):
             if type(text) is str:
-                self._text = array.array("u", text)
+                self._text = array.array(_UNICODE_ARRAY_TYPECODE, text)
             else:
                 self._text = array.array("c", text)
             self._use_tostring = True
@@ -206,9 +215,9 @@ class SpellChecker:
 
     def _array_to_string(self, text):
         """Format an internal array as a standard string."""
-        if text.typecode == "u":
+        if text.typecode in _UNICODE_ARRAY_TYPECODES:
             return text.tounicode()
-        return text.tostring()
+        return text.tobytes().decode()
 
     def wants_unicode(self) -> bool:
         """Check whether the checker wants unicode strings.
@@ -217,7 +226,7 @@ class SpellChecker:
         as input, `False` if it wants normal strings.  It's important to
         provide the correct type of string to the checker.
         """
-        return self._text.typecode == "u"
+        return self._text.typecode in _UNICODE_ARRAY_TYPECODES
 
     def coerce_string(self, text: str, enc: Optional[str] = None) -> str:
         """Coerce string into the required type.

--- a/enchant/tokenize/__init__.py
+++ b/enchant/tokenize/__init__.py
@@ -118,6 +118,8 @@ from enchant.errors import TokenizerNotFoundError
 
 Token = Tuple[str, int]
 
+_UNICODE_ARRAY_TYPECODES = {"u", "w"}
+
 #  For backwards-compatibility.  This will eventually be removed, but how
 #  does one mark a module-level constant as deprecated?
 Error = TokenizerNotFoundError
@@ -447,10 +449,9 @@ class Filter:
 
         def _to_string(self, word) -> str:
             if type(word) is array.array:
-                if word.typecode == "u":
+                if word.typecode in _UNICODE_ARRAY_TYPECODES:
                     return word.tounicode()
-                elif word.typecode == "c":
-                    return word.tostring()
+                return word.tobytes().decode()
             return word
 
         # Pass on access to 'offset' to the underlying tokenizer.

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -33,7 +33,7 @@ import pytest
 
 import enchant
 import enchant.tokenize
-from enchant.checker import SpellChecker
+from enchant.checker import _UNICODE_ARRAY_TYPECODE, SpellChecker
 from enchant.errors import DefaultLanguageNotFoundError
 from enchant.utils import get_default_language
 
@@ -181,7 +181,7 @@ def test_unicode():
 
 def test_chararray():
     """Test SpellChecker with a character array as input."""
-    atype = "u"
+    atype = _UNICODE_ARRAY_TYPECODE
     text = "I wll be stord in an aray"
     txtarr = array.array(atype, text)
     chkr = SpellChecker("en_US", txtarr)
@@ -200,6 +200,12 @@ def test_chararray():
             chkr.replace("array")
     assert n == 2
     assert txtarr.tounicode() == "I wll be stored in an array"
+
+
+def test_array_to_string_decodes_byte_arrays():
+    """Test SpellChecker byte array conversion returns text."""
+    chkr = SpellChecker.__new__(SpellChecker)
+    assert chkr._array_to_string(array.array("B", b"text")) == "text"
 
 
 def test_pwl():

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -27,12 +27,14 @@
 # file, but you are not obligated to do so.  If you do not wish to
 # do so, delete this exception statement from your version.
 #
+import array
 import textwrap
 
 import pytest
 
 from enchant.tokenize import (
     EmailFilter,
+    Filter,
     HTMLChunker,
     URLFilter,
     WikiWordFilter,
@@ -42,6 +44,21 @@ from enchant.tokenize import (
     wrap_tokenizer,
 )
 from enchant.tokenize.en import tokenize as tokenize_en
+
+
+def test_filter_skip_decodes_byte_arrays():
+    """Test Filter skip checks see byte arrays as text."""
+
+    def tokenize_byte_array(_text):
+        return iter([(array.array("B", b"skip"), 0), (array.array("B", b"keep"), 5)])
+
+    class SkipFilter(Filter):
+        def _skip(self, word):
+            return word == "skip"
+
+    assert list(SkipFilter(tokenize_byte_array)("ignored")) == [
+        (array.array("B", b"keep"), 5)
+    ]
 
 
 def test_basic_tokenize():

--- a/website/content/changelog.rst
+++ b/website/content/changelog.rst
@@ -5,6 +5,8 @@ Changelog
 ------------------
 
 * Supported Python versions: remove 3.9, add 3.14
+* Avoid deprecated ``array("u")`` usage in ``enchant.checker`` on Python versions
+  that support the replacement Unicode array typecode
 
 3.3.0 (2025-09-14)
 ------------------


### PR DESCRIPTION
Closes pyenchant/pyenchant#324.

This avoids creating `array("u")` buffers in `enchant.checker` on Python versions that support the replacement Unicode array typecode.

What changed:

- use `array("w")` for checker text buffers when the runtime supports it, with `array("u")` as the fallback for older supported Python versions
- treat both `u` and `w` arrays as Unicode in the checker and tokenizer conversion paths
- update the char-array checker test to use the runtime-selected Unicode typecode
- add a changelog note

Validation:

- `tox -e linters,website,py312`
- `tox -e py313` with Python 3.13.12
- Python 3.13 warning-as-error checker smoke: selected `array("w")` and completed replacements without `DeprecationWarning`
- `git diff --check`
- `python3.12 -m compileall -q enchant tests`
- review-fix-loop: no actionable regressions in the staged changes

GitHub Actions currently show `action_required` with zero exposed jobs for this fork branch, so upstream CI has not run yet.
